### PR TITLE
Allow YAML-configured and auto-detected sources in DataFrameReader

### DIFF
--- a/components/toshiba_ab/toshiba_ab.cpp
+++ b/components/toshiba_ab/toshiba_ab.cpp
@@ -858,7 +858,8 @@ void ToshibaAbClimate::process_received_data(const struct DataFrame *frame) {
         if (frame->opcode1 == OPCODE_PARAMETER && frame->data_length >= 4) {
           ESP_LOGI(TAG, "Auto-detected master address: 0x%02X, updating master address", frame->source);
           this->master_address_ = frame->source;
-
+          this->data_reader.add_allowed_source(this->master_address_);
+          this->data_reader.set_allow_unknown_sources(false);
         }
       }
     }
@@ -1119,4 +1120,5 @@ void ToshibaAbVentSwitch::write_state(bool state) {
 
 void esphome::toshiba_ab::ToshibaAbClimate::set_master_address(uint8_t address) {
   this->master_address_ = address;
+  this->data_reader.add_allowed_source(address);
 }


### PR DESCRIPTION
### Motivation
- The frame reader previously dropped frames whose source byte was not in a hardcoded whitelist, which blocked YAML-configured master/source addresses from being accepted.  
- YAML allows configuring a custom master address and the reader must accept those frames.  
- While auto-detecting the master address the reader should temporarily accept unknown sources to find the master.  

### Description
- Added an `allowed_sources_` `std::vector<uint8_t>` to `DataFrameReader` (pre-seeded with the previous whitelist) and replaced the static whitelist check with iteration over this vector.  
- Added `add_allowed_source(uint8_t)` and `set_allow_unknown_sources(bool)` to `DataFrameReader` and included `<algorithm>` for `std::find`.  
- Updated `ToshibaAbClimate::set_master_address(uint8_t)` and the auto-detect code path to call `data_reader.add_allowed_source(...)` and to restore filtering after detection, and made `set_master_address_auto(bool)` toggle the temporary bypass via `set_allow_unknown_sources`.  

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69477366a8b8832fbc5552ac2b81e111)