### PR TITLE
Allow YAML and auto-detected DataFrame sources; update climate feature flags

### DIFF
--- a/components/toshiba_ab/toshiba_ab.cpp
+++ b/components/toshiba_ab/toshiba_ab.cpp
@@ -524,8 +524,8 @@ climate::ClimateFanMode to_climate_fan(const struct TccState *state) {
 
 ToshibaAbClimate::ToshibaAbClimate() {
   target_temperature = NAN;
-  this->traits_.set_supports_action(true);
-  this->traits_.set_supports_current_temperature(true);
+  this->traits_.add_feature_flags(climate::CLIMATE_SUPPORTS_ACTION);
+  this->traits_.add_feature_flags(climate::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE);
   this->traits_.set_supported_modes({
       climate::CLIMATE_MODE_OFF,
       climate::CLIMATE_MODE_HEAT,
@@ -541,7 +541,6 @@ ToshibaAbClimate::ToshibaAbClimate() {
       climate::CLIMATE_FAN_MEDIUM,
       climate::CLIMATE_FAN_HIGH,
   });
-  this->traits_.set_supports_two_point_target_temperature(false);
   this->traits_.set_visual_min_temperature(18);
   this->traits_.set_visual_max_temperature(29);
   this->traits_.set_visual_temperature_step(0.5);
@@ -858,7 +857,8 @@ void ToshibaAbClimate::process_received_data(const struct DataFrame *frame) {
         if (frame->opcode1 == OPCODE_PARAMETER && frame->data_length >= 4) {
           ESP_LOGI(TAG, "Auto-detected master address: 0x%02X, updating master address", frame->source);
           this->master_address_ = frame->source;
-
+          this->data_reader.add_allowed_source(this->master_address_);
+          this->data_reader.set_allow_unknown_sources(false);
         }
       }
     }
@@ -1119,4 +1119,5 @@ void ToshibaAbVentSwitch::write_state(bool state) {
 
 void esphome::toshiba_ab::ToshibaAbClimate::set_master_address(uint8_t address) {
   this->master_address_ = address;
+  this->data_reader.add_allowed_source(address);
 }


### PR DESCRIPTION
### Motivation
- The DataFrame reader previously dropped frames whose source byte was not in a hardcoded whitelist, preventing YAML-configured master/source addresses from being accepted.
- While auto-detecting the master address the reader needed to accept unknown sources temporarily so detection can succeed.
- The climate implementation used deprecated trait setters which caused compilation warnings/errors and needed the newer feature flags API.

### Description
- Replaced the static whitelist with an `allowed_sources_` `std::vector<uint8_t>` inside `DataFrameReader` and iterate over it when checking the initial source byte.
- Added `add_allowed_source(uint8_t)` and `set_allow_unknown_sources(bool)` to `DataFrameReader` and included `<algorithm>` for `std::find`.
- Updated `ToshibaAbClimate::set_master_address(uint8_t)` to call `data_reader.add_allowed_source(...)`, made `set_master_address_auto(bool)` toggle the temporary bypass via `data_reader.set_allow_unknown_sources(...)`, and updated the auto-detect path to register the detected master and restore filtering.
- Replaced deprecated climate trait setters with `add_feature_flags(...)` using the `CLIMATE_SUPPORTS_*` constants and removed the redundant two-point temperature setter to silence warnings.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69477366a8b8832fbc5552ac2b81e111)