### PR TITLE
Add dedicated wrapped-frame receive handler for master keepalive

### DIFF
--- a/components/toshiba_ab/toshiba_ab.h
+++ b/components/toshiba_ab/toshiba_ab.h
@@ -524,6 +524,7 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
   TccState tcc_state;
 
   void process_received_data(const struct DataFrame *frame);
+  void process_received_data_wrapped_(const struct DataFrame *frame);
   size_t send_new_state(const struct TccState *new_state);
   void sync_from_received_state();
   bool is_own_tx_echo_(const DataFrame *f) const; //used to filter echo after sending frame


### PR DESCRIPTION
### Motivation
- Wrapped-frame format needs separate parsing logic from normal frames for clarity and future expansion. 
- The initial wrapped-frame handler must detect the master keepalive pattern and allow auto-detection of the master address for devices that use wrapped frames.

### Description
- Added a new method declaration `process_received_data_wrapped_(const DataFrame *frame)` to the climate class interface. 
- Implemented `process_received_data_wrapped_` to validate wrapped frame size, extract the length and master address, detect the keepalive pattern (length `0x0A` and two bytes before CRC `0x00` and `0x3A`), update `last_master_alive_millis_`, publish the connected sensor, and auto-set the master via `set_master_address` when appropriate. 
- Routed wrapped frames through the new handler by checking `frame->is_wrapped()` inside `receive_data_frame` while leaving the existing `process_received_data` path untouched for normal frames. 
- Added logging calls (`log_raw_data` / `ESP_LOGI`) to aid debugging of wrapped frames and keepalive detection.

### Testing
- No automated tests were run on the modified code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975e1df95b4832f951611481be192e3)