### PR TITLE
Fix wrapped frame header parsing and gated wrapped status decoding

### DIFF
--- a/components/toshiba_ab/toshiba_ab.cpp
+++ b/components/toshiba_ab/toshiba_ab.cpp
@@ -997,7 +997,10 @@ void ToshibaAbClimate::process_received_data_wrapped_(const struct DataFrame *fr
   }
 
   const uint8_t frame_length = frame->raw[0];
-  const uint8_t master_address = frame->raw[1];
+  const uint8_t source = frame->raw[1];
+  const uint8_t dest = frame->raw[2];
+  const uint8_t payload_length = frame->raw[3];
+  const size_t payload_offset = 4;
   const bool has_tail_signature =
       size >= 3 && frame->raw[size - 3] == 0x00 && frame->raw[size - 2] == 0x3A;
 
@@ -1008,10 +1011,44 @@ void ToshibaAbClimate::process_received_data_wrapped_(const struct DataFrame *fr
       this->connected_binary_sensor_->publish_state(true);
     }
 
-    if (this->master_address_auto_ && this->master_address_ == 0x00 && master_address != 0x00) {
-      ESP_LOGI(TAG, "Auto-detected master address from wrapped keepalive: 0x%02X", master_address);
-      this->set_master_address(master_address);
+    if (this->master_address_auto_ && this->master_address_ == 0x00 && source != 0x00) {
+      ESP_LOGI(TAG, "Auto-detected master address from wrapped keepalive: 0x%02X", source);
+      this->set_master_address(source);
     }
+    return;
+  }
+
+  if (dest == 0xFF && payload_length >= STATUS_DATA_TARGET_TEMP_BYTE + 1 &&
+      size >= payload_offset + payload_length) {
+    if (frame->raw[payload_offset] != 0xC0 || frame->raw[payload_offset + 1] != 0x38) {
+      log_raw_data("Wrapped data: ", frame->raw, size);
+      return;
+    }
+    const uint8_t *payload = &frame->raw[payload_offset];
+    log_raw_data("Wrapped status: ", frame->raw, size);
+    tcc_state.power = (payload[STATUS_DATA_MODEPOWER_BYTE] & STATUS_DATA_POWER_MASK);
+    tcc_state.mode =
+        (payload[STATUS_DATA_MODEPOWER_BYTE] & STATUS_DATA_MODE_MASK) >> STATUS_DATA_MODE_SHIFT_BITS;
+    tcc_state.fan = (payload[STATUS_DATA_FANVENT_BYTE] & STATUS_DATA_FAN_MASK) >> STATUS_DATA_FAN_SHIFT_BITS;
+    tcc_state.vent =
+        (payload[STATUS_DATA_FANVENT_BYTE] & STATUS_DATA_VENT_MASK) >> STATUS_DATA_VENT_SHIFT_BITS;
+    tcc_state.target_temp =
+        static_cast<float>(payload[STATUS_DATA_TARGET_TEMP_BYTE]) / TEMPERATURE_CONVERSION_RATIO -
+        TEMPERATURE_CONVERSION_OFFSET;
+    if (payload_length > STATUS_DATA_TARGET_TEMP_BYTE + 1 &&
+        payload[STATUS_DATA_TARGET_TEMP_BYTE + 1] > 1) {
+      tcc_state.room_temp =
+          static_cast<float>(payload[STATUS_DATA_TARGET_TEMP_BYTE + 1]) / TEMPERATURE_CONVERSION_RATIO -
+          TEMPERATURE_CONVERSION_OFFSET;
+    }
+    tcc_state.preheating = (payload[STATUS_DATA_FLAGS_BYTE] & 0b00000010) >> 1;
+    tcc_state.filter_alert = (payload[STATUS_DATA_FLAGS_BYTE] & 0b10000000) >> 7;
+
+    ESP_LOGD(TAG,
+             "Wrapped status power=%d mode=%02X fan=%02X vent=%02X target=%.1f room=%.1f preheat=%d filter=%d",
+             tcc_state.power, tcc_state.mode, tcc_state.fan, tcc_state.vent, tcc_state.target_temp,
+             tcc_state.room_temp, tcc_state.preheating, tcc_state.filter_alert);
+    sync_from_received_state();
     return;
   }
 


### PR DESCRIPTION
### Motivation
- Wrapped frames place opcode and addressing bytes at different offsets than normal frames, so wrapped messages were being mis-parsed and master autodetect/status decoding could use the wrong byte.
- The change ensures the library correctly interprets wrapped header fields (length/source/destination/payload length) and only decodes status payloads when they match the expected broadcast destination and payload signature.

### Description
- Reinterpreted wrapped header bytes in `process_received_data_wrapped_` as `frame_length`, `source`, `dest`, and `payload_length` instead of treating the 3rd byte as `opcode` and the 2nd as `master_address` in `components/toshiba_ab/toshiba_ab.cpp`.
- Updated master auto-detection to use the wrapped `source` byte when `master_address_auto_` is enabled and `master_address_` is unset.
- Gate wrapped status decoding on `dest == 0xFF`, require the `C0:38` signature at the start of the payload, and add payload bounds checks before mapping bytes into `tcc_state` fields.
- Added defensive logging (`log_raw_data` / `ESP_LOGD`) when wrapped frames are ignored or when status is decoded.

### Testing
- No automated tests were run for this change (not requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975e585b9fc832fbf128aade7055949)