### PR TITLE
Fix wrapped frame length handling

### DIFF
--- a/components/toshiba_ab/toshiba_ab.h
+++ b/components/toshiba_ab/toshiba_ab.h
@@ -284,7 +284,10 @@ struct DataFrameReader {
         if (wrapped_expected_total_ < 1 || (wrapped_expected_total_ - 1) > DATA_FRAME_MAX_SIZE) {
           ESP_LOGV("READER", "Invalid wrapped length 0x%02X; resetting reader", current_byte);
           reset();
+          return false;
         }
+        frame.raw[data_index_] = current_byte;
+        data_index_++;
         return false;
       }
 


### PR DESCRIPTION
### Motivation
- The wrapped-frame reader was dropping the wrapped length byte which misaligned payload indexing and could lead to incorrect parsing and CRC failures for wrapped frames.

### Description
- In `components/toshiba_ab/toshiba_ab.h` updated `DataFrameReader::put()` so that when `wrapped_len_pending_` is handled the length byte is preserved into `frame.raw[data_index_]` and `data_index_` is incremented, and added an early `return false` on invalid wrapped lengths to avoid recording bad frames.

### Testing
- No automated tests were run for this change (no CI/unit tests executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976a1a099f0832f9535d56d9b402c72)