### PR TITLE
Guard UART device logging in Toshiba AB component

### DIFF
--- a/components/toshiba_ab/toshiba_ab.cpp
+++ b/components/toshiba_ab/toshiba_ab.cpp
@@ -586,7 +586,11 @@ climate::ClimateTraits ToshibaAbClimate::traits() { return traits_; }
 
 void ToshibaAbClimate::dump_config() {
   ESP_LOGCONFIG(TAG, "TCC Link:");
+#ifdef LOG_UART_DEVICE
   LOG_UART_DEVICE(this);
+#else
+  ESP_LOGCONFIG(TAG, "  UART: logging unavailable");
+#endif
   this->dump_traits_(TAG);
   ESP_LOGCONFIG(TAG, "  Master address: 0x%02X", this->master_address_);
   ESP_LOGCONFIG(TAG, "  Master address auto: %s", this->master_address_auto_ ? "true" : "false");


### PR DESCRIPTION
### Motivation
- Prevent build failures when the `LOG_UART_DEVICE` logging macro is not available by providing a guarded fallback in the component's `dump_config()`.

### Description
- Wrap the call to `LOG_UART_DEVICE(this)` in `#ifdef LOG_UART_DEVICE` and emit a fallback `ESP_LOGCONFIG` message when the macro is absent in `components/toshiba_ab/toshiba_ab.cpp`.

### Testing
- No automated tests were run after the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697800eb13ac832fbbbabea04881d664)