### PR TITLE
Add wrapped set-parameter flags frame support

### DIFF
--- a/components/toshiba_ab/toshiba_ab.h
+++ b/components/toshiba_ab/toshiba_ab.h
@@ -20,7 +20,9 @@ const uint32_t FRAME_SEND_MILLIS_FROM_LAST_RECEIVE = 500;
 const uint32_t FRAME_SEND_MILLIS_FROM_LAST_SEND = 500;
 
 // const uint8_t TOSHIBA_MASTER = 0x00;  replaced by master_address_ which is set up in yaml
-const uint8_t TOSHIBA_REMOTE = 0x40;  
+const uint8_t TOSHIBA_REMOTE = 0x40;
+const uint8_t TOSHIBA_WRAPPED_REMOTE_DEFAULT = 0x50;
+const uint8_t TOSHIBA_WRAPPED_MASTER_DEFAULT = 0x90;
 const uint8_t TOSHIBA_TEMP_SENSOR = 0x42;
 const uint8_t TOSHIBA_BROADCAST = 0xF0;
 const uint8_t TOSHIBA_REPORT = 0x52;
@@ -456,6 +458,8 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
   
   uint8_t master_address_ = 0x00;
   bool master_address_auto_{true};
+  uint8_t wrapped_remote_address_{TOSHIBA_WRAPPED_REMOTE_DEFAULT};
+  uint8_t wrapped_master_address_{TOSHIBA_WRAPPED_MASTER_DEFAULT};
   void set_master_address(uint8_t address);
   void set_master_address_auto(bool auto_detect) {
     master_address_auto_ = auto_detect;


### PR DESCRIPTION
### Motivation
- Support sending the special "wrapped" command frame format (F0:F0 ... A0) for set-parameter (fan/temp) operations so wrapped devices can be controlled separately from normal frames.
- Keep wrapped-frame logic separate from normal frames and provide a dedicated CRC routine for this wrapped command type.

### Description
- Added a CRC helper `calculate_wrapped_set_parameter_flags_crc` that computes CRC as `(0xB8 + sum(data[0..n-1])) & 0xFF` for the wrapped set-parameter flags payload.
- Implemented `write_set_parameter_flags_wrapped` which builds the wrapped raw frame bytes (length, remote, master, payload length, marker bytes `0x01:0x2C`, mode/fan/target/empty/get_heat_cool_bits twice, CRC) and marks the `DataFrame` as wrapped with `set_wrapped(true)`.
- Added default wrapped-address constants `TOSHIBA_WRAPPED_REMOTE_DEFAULT` and `TOSHIBA_WRAPPED_MASTER_DEFAULT` and instance fields `wrapped_remote_address_` / `wrapped_master_address_` to `ToshibaAbClimate` for later configurability.
- Updated `create_commands` to choose the wrapped builder (`write_set_parameter_flags_wrapped`) when `data_reader.frame_format() == FrameFormat::WRAPPED`, and modified `loop()` send logic to prefix queued wrapped frames with `0xF0,0xF0` and append `0xA0` when writing to the bus.
- Minor includes and use of `std::memcpy` added to support sending wrapped buffers.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69794ca51c40832fa7eddd243e55916f)