### PR TITLE
Add boot-log capture/replay and boot-log button wiring (revert docs changes)

### DIFF
--- a/components/toshiba_ab/climate.py
+++ b/components/toshiba_ab/climate.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import automation
-from esphome.components import climate, uart, binary_sensor, sensor, switch, text_sensor, template
+from esphome.components import climate, uart, binary_sensor, sensor, switch, text_sensor, template, button
 from esphome.const import (
     CONF_ID,
     CONF_NAME,
@@ -19,7 +19,7 @@ from esphome.const import (
 )
 
 DEPENDENCIES = ["uart"]
-AUTO_LOAD = ["climate", "binary_sensor", "sensor", "switch"]
+AUTO_LOAD = ["climate", "binary_sensor", "sensor", "switch", "button"]
 CODEOWNERS = ["@muxa"]
 
 toshiba_ab_ns = cg.esphome_ns.namespace("toshiba_ab")
@@ -28,6 +28,7 @@ CONF_CONNECTED = "connected"
 CONF_VENT = "vent"
 CONF_READ_ONLY_SWITCH = "read_only_switch"
 CONF_FAILED_CRCS = "failed_crcs"
+CONF_BOOT_LOG_PRINT = "boot_log_print"
 
 CONF_ON_DATA_RECEIVED = "on_data_received"
 CONF_MASTER = "master"
@@ -64,6 +65,10 @@ ToshibaAbVentSwitch =  toshiba_ab_ns.class_(
 
 ToshibaAbReadOnlySwitch = toshiba_ab_ns.class_(
     "ToshibaAbReadOnlySwitch", switch.Switch, cg.Component
+)
+
+ToshibaAbBootLogButton = toshiba_ab_ns.class_(
+    "ToshibaAbBootLogButton", button.Button, cg.Component
 )
 
 ToshibaAbOnDataReceivedTrigger = toshiba_ab_ns.class_(
@@ -120,6 +125,7 @@ CONFIG_SCHEMA = climate._CLIMATE_SCHEMA.extend(
             ),
             key=CONF_NAME,
         ),
+        cv.Optional(CONF_BOOT_LOG_PRINT): button.button_schema(ToshibaAbBootLogButton),
         cv.Optional(CONF_FAILED_CRCS): sensor.sensor_schema(
             accuracy_decimals=0,
             entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
@@ -179,6 +185,12 @@ async def to_code(config):
     if CONF_READ_ONLY_SWITCH in config:
         sw = await switch.new_switch(config[CONF_READ_ONLY_SWITCH], var)
         cg.add(var.set_read_only_switch(sw))
+
+    if CONF_BOOT_LOG_PRINT in config:
+        boot_button = cg.new_Pvariable(config[CONF_BOOT_LOG_PRINT][CONF_ID], var)
+        await cg.register_component(boot_button, config[CONF_BOOT_LOG_PRINT])
+        await button.register_button(boot_button, config[CONF_BOOT_LOG_PRINT])
+        cg.add(var.set_boot_log_capture_enabled(True))
 
     if CONF_ON_DATA_RECEIVED in config:
         for on_data_received in config.get(CONF_ON_DATA_RECEIVED, []):


### PR DESCRIPTION
### Motivation
- Capture early boot logs and provide a way to replay them from the running device to aid debugging of AC link/setup issues.
- Wire a configured `button` into the component so a user-pressed button can trigger the boot-log replay.
- Remove accidental documentation and example YAML modifications from the PR so only code changes remain.

### Description
- Added boot-log capture window constant `BOOT_LOG_CAPTURE_WINDOW_MS`, a `BootLogEntry` struct, and a `std::vector<BootLogEntry>` to store captured entries in `toshiba_ab.h`.
- Implemented `capture_boot_log_()` and `print_boot_logs()` methods and related flags/fields in `toshiba_ab.cpp` to capture logs via `logger::global_logger` and replay them with proper log levels and timestamps.
- Introduced `ToshibaAbBootLogButton` class in `toshiba_ab.h` that calls `print_boot_logs()` on `press_action()`, and added the `button` component wiring in `components/toshiba_ab/climate.py` including schema entry `boot_log_print`, `AUTO_LOAD` update, registering the button, and enabling capture with `set_boot_log_capture_enabled(True)`.
- Added necessary includes (`button` in headers and `logger.h` in the CPP) and small config/schema updates to support the new button option.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69806c9d22a8832f92542cb42096f470)