### PR TITLE
Fix boot log replay handling for ESP8266 builds

### DIFF
--- a/components/toshiba_ab/toshiba_ab.h
+++ b/components/toshiba_ab/toshiba_ab.h
@@ -588,7 +588,7 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
 
  private:
   struct BootLogEntry {
-    int level;
+    uint8_t level;
     std::string tag;
     std::string message;
     uint32_t millis_since_boot;
@@ -615,7 +615,7 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
   bool boot_log_capture_enabled_{false};
   bool boot_log_capture_active_{false};
   bool boot_log_replay_active_{false};
-  void capture_boot_log_(int level, const char *tag, const char *message);
+  void capture_boot_log_(uint8_t level, const char *tag, const char *message, size_t message_length);
 
 };
 


### PR DESCRIPTION
### Motivation
- Build failures occurred when replaying captured logs on some targets because `ESP_LOG_LEVEL` is not available and the logger callback signature differs between ESPHome builds. 
- The existing code stored log level as an `int` and captured messages without an explicit length, which could lead to mismatches when the logger supplies a message length. 
- Replay should use concrete ESP logging macros mapped to captured levels so logs are emitted correctly across platforms.

### Description
- Changed `BootLogEntry::level` from `int` to `uint8_t` to match the logger callback level type in ESPHome and make the type explicit in `components/toshiba_ab/toshiba_ab.h`.
- Updated the capture function signature to `capture_boot_log_(uint8_t level, const char *tag, const char *message, size_t message_length)` and store the message honoring the provided `message_length` in `components/toshiba_ab/toshiba_ab.cpp`.
- Replaced the use of the unavailable `ESP_LOG_LEVEL` macro with an explicit `switch` that maps captured levels to `ESP_LOGE/W/I/D/V` so replay uses the correct macro per level in `components/toshiba_ab/toshiba_ab.cpp`.
- Adjusted the logger callback registration to the matching `std::function` signature and call the new capture function with the provided `length` in `components/toshiba_ab/toshiba_ab.cpp`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980846ea024832fbfeaaf4a44320a66)