### PR TITLE
Use API log level enums in Toshiba AB boot log replay

### DIFF
--- a/components/toshiba_ab/toshiba_ab.cpp
+++ b/components/toshiba_ab/toshiba_ab.cpp
@@ -650,23 +650,23 @@ void ToshibaAbClimate::print_boot_logs() {
            static_cast<float>(BOOT_LOG_CAPTURE_WINDOW_MS) / 1000.0f);
   for (const auto &entry : this->boot_log_entries_) {
     switch (entry.level) {
-      case logger::LOG_LEVEL_ERROR:
+      case api::enums::LOG_LEVEL_ERROR:
         ESP_LOGE(entry.tag.c_str(), "[boot+%u ms] %s", entry.millis_since_boot, entry.message.c_str());
         break;
-      case logger::LOG_LEVEL_WARN:
+      case api::enums::LOG_LEVEL_WARN:
         ESP_LOGW(entry.tag.c_str(), "[boot+%u ms] %s", entry.millis_since_boot, entry.message.c_str());
         break;
-      case logger::LOG_LEVEL_INFO:
+      case api::enums::LOG_LEVEL_INFO:
         ESP_LOGI(entry.tag.c_str(), "[boot+%u ms] %s", entry.millis_since_boot, entry.message.c_str());
         break;
-      case logger::LOG_LEVEL_DEBUG:
+      case api::enums::LOG_LEVEL_DEBUG:
         ESP_LOGD(entry.tag.c_str(), "[boot+%u ms] %s", entry.millis_since_boot, entry.message.c_str());
         break;
-      case logger::LOG_LEVEL_VERBOSE:
-      case logger::LOG_LEVEL_VERY_VERBOSE:
+      case api::enums::LOG_LEVEL_VERBOSE:
+      case api::enums::LOG_LEVEL_VERY_VERBOSE:
         ESP_LOGV(entry.tag.c_str(), "[boot+%u ms] %s", entry.millis_since_boot, entry.message.c_str());
         break;
-      case logger::LOG_LEVEL_NONE:
+      case api::enums::LOG_LEVEL_NONE:
       default:
         break;
     }


### PR DESCRIPTION
### Motivation
- Fix a compile error caused by using `logger::LOG_LEVEL_*` identifiers that are not defined in the current logger API and are declared under `api::enums` instead.

### Description
- Replace `logger::LOG_LEVEL_*` with `api::enums::LOG_LEVEL_*` in `ToshibaAbClimate::print_boot_logs()` so boot log replay uses the correct enum namespace.

### Testing
- No automated tests were run; the change is small and the build/compile was not re-run, so the build status is unverified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69808571ce1c832fbe9b460742295415)