### PR TITLE
Rename 'wrapped' identifiers to 'TU2C' and add canonical frame-format aliases

### DIFF
--- a/components/toshiba_ab/climate.py
+++ b/components/toshiba_ab/climate.py
@@ -73,7 +73,11 @@ ToshibaAbOnDataReceivedTrigger = toshiba_ab_ns.class_(
 FrameFormat = toshiba_ab_ns.enum("FrameFormat")
 FRAME_FORMATS = {
     "n": FrameFormat.NORMAL,
-    "u": FrameFormat.WRAPPED,
+    "normal": FrameFormat.NORMAL,
+    "u": FrameFormat.TU2C,
+    "wrapped": FrameFormat.TU2C,
+    "tu2c": FrameFormat.TU2C,
+    "tcc-link": FrameFormat.NORMAL,
 }
 
 


### PR DESCRIPTION
### Motivation
- Use the canonical TU2C / TCC-Link terminology in code, logs and configuration to reduce ambiguity and match user-facing naming.
- Replace legacy/ambiguous `wrapped` identifiers with `tu2c` in internal APIs for clearer intent and maintainability.

### Description
- Renamed DataFrame API and flag from `set_wrapped`/`is_wrapped` and `wrapped_` to `set_tu2c`/`is_tu2c` and `tu2c_` in `components/toshiba_ab/toshiba_ab.h`.
- Replaced `WRAPPED` enum/constant with `TU2C` and updated TU2C address defaults to `TOSHIBA_TU2C_REMOTE_DEFAULT`/`TOSHIBA_TU2C_MASTER_DEFAULT`.
- Renamed parser/internal members and variables (`wrapped_len_pending_`, `wrapped_expected_total_`, `wrapped_bytes_seen_`, `use_wrapped`, etc.) to `tu2c_*` variants and updated the reader logic accordingly in `toshoba_ab.h`/`.cpp`.
- Renamed TU2C-specific functions and call sites: `calculate_wrapped_set_parameter_flags_crc` → `calculate_tu2c_set_parameter_flags_crc`, `write_set_parameter_flags_wrapped` → `write_set_parameter_flags_tu2c`, and `process_received_data_wrapped_` → `process_received_data_tu2c_` and updated all usages in `components/toshiba_ab/toshiba_ab.cpp`.
- Updated user-facing log messages and diagnostic strings from “Wrapped …” to “TU2C …”, and adjusted the transmit path to build TU2C-wrapped frames when needed.
- Extended YAML `FRAME_FORMATS` aliases in `components/toshiba_ab/climate.py` to accept canonical values (`tu2c`, `tcc-link`) while keeping legacy aliases (`wrapped`, `normal`, `u`, `n`) for backward compatibility.

### Testing
- Ran `python -m compileall components/toshiba_ab/climate.py` and it completed successfully.
- No automated C++ build was executed in this environment; changes are identifier renames, logic is unchanged aside from naming and logs, so a full project build is recommended to verify C++ compilation in CI or local toolchain.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985d165364c832f8dec53e7ca22c75f)