### PR TITLE
Add configurable `filter_frames` option for TCC-Link source validation

### DIFF
--- a/complete_example.yaml
+++ b/complete_example.yaml
@@ -75,6 +75,7 @@ climate:
     command_mode_read: 0x08     # optional, defaults to 0x08 if omitted; use 0x0D for some commercial systems
     command_mode_write: 0x80    # optional, defaults to 0x80 if omitted; use 0xD0 for some commercial systems
     frame_format: N             # optional, use "U" if your bus uses F0 F0 ... A0 framing
+    filter_frames: true         # optional, default true; reject normal TCC-Link frames with source > 0xA0
 
     ###### Optional settings  #######
 

--- a/components/toshiba_ab/climate.py
+++ b/components/toshiba_ab/climate.py
@@ -35,6 +35,7 @@ CONF_MASTER_ADDRESS_AUTO = "master_address_auto"
 CONF_COMMAND_MODE_READ = "command_mode_read"
 CONF_COMMAND_MODE_WRITE = "command_mode_write"
 CONF_FRAME_FORMAT = "frame_format"
+CONF_FILTER_FRAMES = "filter_frames"
 
 CONF_AUTONOMOUS = "autonomous"
 CONF_READ_ONLY = "read_only"
@@ -98,7 +99,8 @@ CONFIG_SCHEMA = climate._CLIMATE_SCHEMA.extend(
         cv.Optional(CONF_COMMAND_MODE_READ, default=0x08): cv.uint8_t,
         cv.Optional(CONF_COMMAND_MODE_WRITE, default=0x80): cv.uint8_t,
         cv.Optional(CONF_FRAME_FORMAT, default="n"): cv.one_of(*FRAME_FORMATS, lower=True),
-    
+        cv.Optional(CONF_FILTER_FRAMES, default=True): cv.boolean,
+
         cv.GenerateID(): cv.declare_id(ToshibaAbClimate),
         cv.Optional(CONF_CONNECTED): binary_sensor.binary_sensor_schema(
             device_class = DEVICE_CLASS_CONNECTIVITY,
@@ -168,6 +170,8 @@ async def to_code(config):
         cg.add(var.set_command_mode_write(config[CONF_COMMAND_MODE_WRITE]))
     if CONF_FRAME_FORMAT in config:
         cg.add(var.set_frame_format(FRAME_FORMATS[config[CONF_FRAME_FORMAT]]))
+    if CONF_FILTER_FRAMES in config:
+        cg.add(var.set_filter_frames(config[CONF_FILTER_FRAMES]))
 
     if CONF_CONNECTED in config:
         sens = await binary_sensor.new_binary_sensor(config[CONF_CONNECTED])


### PR DESCRIPTION
### Motivation
- Replace the previous per-reader `allow_unknown_sources` gating with a simpler, YAML-configurable option to control obvious-source filtering.  
- Provide an easy-to-use `filter_frames` toggle (default `true`) so users can opt out when their bus uses nonstandard source values.  
- Keep TU2C handling untouched while tightening heuristics for normal TCC-Link frames to reduce noise.  

### Description
- Replaced `allow_unknown_sources_`/allowed-sources list in `DataFrameReader` with `filter_frames_` and implemented `set_filter_frames()` and `filter_frames()` accessors.  
- Implemented filtering rule in `DataFrameReader::put()`: for non-TU2C frames at frame start, if `filter_frames` is `true` and the source byte is greater than `0xA0`, the byte/frame is ignored.  
- Exposed new YAML option `filter_frames` (default `true`) in `components/toshiba_ab/climate.py` and wired codegen to call `set_filter_frames(...)` on the component.  
- Updated `ToshibaAbClimate` to store/propagate `filter_frames`, removed obsolete allowed-source management calls, and added a `Filter frames` line to `dump_config()`; updated `complete_example.yaml` to document the option.  

### Testing
- Ran Python compile check for the codegen file with `python -m py_compile components/toshiba_ab/climate.py`, which succeeded.  
- Attempted a PlatformIO build with `pio run` but it failed in this environment because `pio` is not installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698724a0b93c832f8d11835cb50e03b9)