### PR TITLE
TU2C: detect ACK frames and add retry/resend for TU2C commands

### DIFF
--- a/components/toshiba_ab/toshiba_ab.cpp
+++ b/components/toshiba_ab/toshiba_ab.cpp
@@ -169,9 +169,16 @@ bool ToshibaAbClimate::is_ack_for_pending_command_(const DataFrame *frame) const
   }
   const auto &pending = this->last_unconfirmed_command_.value();
 
-  // ACK/retry logic is only for classic TCCLink frames, not TU2C.
   if (frame->is_tu2c() || pending.is_tu2c()) {
-    return false;
+    if (!frame->is_tu2c() || !pending.is_tu2c()) {
+      return false;
+    }
+
+    if (frame->raw[1] != pending.raw[2] || frame->raw[2] != pending.raw[1]) {
+      return false;
+    }
+
+    return this->is_tu2c_command_ack_frame_(frame);
   }
 
   if (frame->source != pending.dest || frame->dest != pending.source) {
@@ -185,9 +192,39 @@ bool ToshibaAbClimate::is_ack_for_pending_command_(const DataFrame *frame) const
   return frame->data[0] == this->command_mode_write_ && frame->data[1] == OPCODE2_PARAM_ACK;
 }
 
+bool ToshibaAbClimate::is_tu2c_command_ack_frame_(const DataFrame *frame) const {
+  if (frame == nullptr || !frame->is_tu2c()) {
+    return false;
+  }
+
+  const size_t size = frame->size();
+  if (size < 7) {
+    return false;
+  }
+
+  return frame->raw[0] == 0x0A && frame->raw[4] == 0x80 && frame->raw[5] == 0xA1;
+}
+
+bool ToshibaAbClimate::should_track_tu2c_command_ack_(const DataFrame &frame) const {
+  if (!frame.is_tu2c() || frame.size() < 7) {
+    return false;
+  }
+
+  if (frame.raw[1] != this->tu2c_remote_address_ || frame.raw[2] != this->tu2c_master_address_) {
+    return false;
+  }
+
+  if (frame.raw[4] != 0x01) {
+    return false;
+  }
+
+  // Track ACKs for TU2C write commands (currently power-off and set-parameter flags).
+  return frame.raw[5] == 0x21 || frame.raw[5] == 0x2C;
+}
+
 bool ToshibaAbClimate::should_track_command_ack_(const DataFrame &frame) const {
   if (frame.is_tu2c()) {
-    return false;
+    return this->should_track_tu2c_command_ack_(frame);
   }
 
   if (frame.opcode1 != OPCODE_PARAMETER || frame.data_length < 2) {
@@ -1392,10 +1429,7 @@ bool ToshibaAbClimate::receive_data_frame(const struct DataFrame *frame) {
     return true;  // swallow quietly
   }
 
-  if (this->last_unconfirmed_command_.has_value() && !frame->is_tu2c() &&
-      !this->last_unconfirmed_command_->is_tu2c() && !this->is_ack_for_pending_command_(frame)) {
-    this->resend_last_unconfirmed_command_ = true;
-  }
+  this->handle_pending_command_ack_(frame);
 
   // still notify any listeners of real frames
   this->set_data_received_callback_.call(frame);
@@ -1429,9 +1463,15 @@ void ToshibaAbClimate::loop() {
         frame_to_send = this->last_unconfirmed_command_.value();
         this->last_unconfirmed_command_attempts_++;
         this->resend_last_unconfirmed_command_ = false;
-        ESP_LOGW(TAG, "Resending command opcode 0x%02X (attempt %u/%u)", frame_to_send->opcode1,
-                 static_cast<unsigned>(this->last_unconfirmed_command_attempts_),
-                 static_cast<unsigned>(MAX_COMMAND_SEND_ATTEMPTS));
+        if (frame_to_send->is_tu2c()) {
+          ESP_LOGD(TAG, "Resending TU2C command (attempt %u/%u)",
+                   static_cast<unsigned>(this->last_unconfirmed_command_attempts_),
+                   static_cast<unsigned>(MAX_COMMAND_SEND_ATTEMPTS));
+        } else {
+          ESP_LOGD(TAG, "Resending command opcode 0x%02X (attempt %u/%u)", frame_to_send->opcode1,
+                   static_cast<unsigned>(this->last_unconfirmed_command_attempts_),
+                   static_cast<unsigned>(MAX_COMMAND_SEND_ATTEMPTS));
+        }
       }
     }
 

--- a/components/toshiba_ab/toshiba_ab.h
+++ b/components/toshiba_ab/toshiba_ab.h
@@ -520,6 +520,8 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
   void process_received_data(const struct DataFrame *frame);
   void process_received_data_tu2c_(const struct DataFrame *frame);
   bool is_ack_for_pending_command_(const DataFrame *frame) const;
+  bool is_tu2c_command_ack_frame_(const DataFrame *frame) const;
+  bool should_track_tu2c_command_ack_(const DataFrame &frame) const;
   bool should_track_command_ack_(const DataFrame &frame) const;
   void handle_pending_command_ack_(const DataFrame *frame);
   size_t send_new_state(const struct TccState *new_state);


### PR DESCRIPTION
### Motivation

- Implement a resend approach for TU2C commands so commands are retried when the expected ACK does not immediately follow the command, matching the existing TCCLink retry behavior.  
- TU2C ACKs are identified by the observed signature (length `0x0A` and payload marker bytes `0x80:0xA1`) and must be treated differently from classic TCCLink ACK frames.  

### Description

- Added `is_tu2c_command_ack_frame_` and `should_track_tu2c_command_ack_` and declared them in the header so TU2C-specific ACK frames can be recognized and selected for tracking.  
- Extended `is_ack_for_pending_command_` to handle TU2C pending commands by verifying the TU2C wrap bytes, source/destination reversal and delegating to the new TU2C ACK detector.  
- Unified ACK handling by calling `handle_pending_command_ack_` for every non-echo received frame so the logic "if ACK is not the next frame, retry" is applied consistently for both TCCLink and TU2C.  
- Track TU2C write command ACK patterns (currently power-off and set-parameter flags) and changed resend logging to debug level (`ESP_LOGD`) while keeping the existing max attempts (`5`).  

### Testing

- Ran `platformio run` in this environment but the build could not be executed because PlatformIO is not installed (`platformio: command not found`).  
- Performed code-level verification with `rg`/`nl`/`sed` to confirm the new functions are declared and referenced and that retry logic paths and log changes were applied successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a913003368832f9fba929bec44373f)