### PR TITLE
feat: protocol_variant config for HM-range Toshiba indoors (RAV-RM/HM)

### DIFF
--- a/components/toshiba_ab/climate.py
+++ b/components/toshiba_ab/climate.py
@@ -99,6 +99,13 @@ FRAME_FORMATS = {
     "tcc-link": FrameFormat.NORMAL,
     "a0": FrameFormat.A0,
     "estia_a0": FrameFormat.A0,
+    # HM-range dialect (RAV-RM/HM indoors paired with TU2C-Link-capable
+    # outdoors). Frames use a 6-byte wrapper that embeds source/dest at
+    # byte offsets 6 / 8 of the on-wire data. The reader canonicalises
+    # them to the same in-memory layout as `normal` so the rest of the
+    # pipeline is unchanged. CRC is currently tolerated rather than
+    # validated (algorithm not yet derived).
+    "hm": FrameFormat.HM,
 }
 
 

--- a/components/toshiba_ab/toshiba_ab.cpp
+++ b/components/toshiba_ab/toshiba_ab.cpp
@@ -342,16 +342,36 @@ void write_set_parameter(struct DataFrame *command, uint8_t master_address, uint
 }
 
 void write_set_parameter_flags(struct DataFrame *command, uint8_t master_address, uint8_t command_mode_read,
-                               const struct TccState *state, uint8_t set_flags) {
-  uint8_t payload[6] = {
-      static_cast<uint8_t>(state->mode | set_flags),
-      static_cast<uint8_t>(state->fan | get_fan_bit_mask_for_mode(state->mode)),
-      temp_celcius_to_payload(state->target_temp),
-      EMPTY_DATA,
-      get_heat_cool_bits(state->mode),
-      get_heat_cool_bits(state->mode),
-  };
-  write_set_parameter(command, master_address, command_mode_read, OPCODE2_SET_TEMP_WITH_FAN, payload, sizeof(payload));
+                               const struct TccState *state, uint8_t set_flags, bool hm_variant) {
+  // The first six payload bytes are identical in both variants. The HM
+  // variant appends three trailing zero bytes that the RBC-ASCU11-E wired
+  // remote sends; without them, the AC controller silently rejects the
+  // command. Captured form for HM:
+  //   4C : <mode|flags> : <fan|mask> : <temp> : 00 : 33 : 33 : 00 : 00 : 00
+  if (hm_variant) {
+    uint8_t payload[9] = {
+        static_cast<uint8_t>(state->mode | set_flags),
+        static_cast<uint8_t>(state->fan | get_fan_bit_mask_for_mode(state->mode)),
+        temp_celcius_to_payload(state->target_temp),
+        EMPTY_DATA,
+        get_heat_cool_bits(state->mode),
+        get_heat_cool_bits(state->mode),
+        EMPTY_DATA,
+        EMPTY_DATA,
+        EMPTY_DATA,
+    };
+    write_set_parameter(command, master_address, command_mode_read, OPCODE2_SET_TEMP_WITH_FAN, payload, sizeof(payload));
+  } else {
+    uint8_t payload[6] = {
+        static_cast<uint8_t>(state->mode | set_flags),
+        static_cast<uint8_t>(state->fan | get_fan_bit_mask_for_mode(state->mode)),
+        temp_celcius_to_payload(state->target_temp),
+        EMPTY_DATA,
+        get_heat_cool_bits(state->mode),
+        get_heat_cool_bits(state->mode),
+    };
+    write_set_parameter(command, master_address, command_mode_read, OPCODE2_SET_TEMP_WITH_FAN, payload, sizeof(payload));
+  }
 }
 
 void write_set_parameter_flags_tu2c(struct DataFrame *command, uint8_t remote_address, uint8_t master_address,
@@ -580,14 +600,25 @@ void ToshibaAbClimate::add_polled_sensor(uint8_t id, float scale, uint32_t inter
   PolledSensor ps{ id, scale, interval_ms, sensor };
   this->polled_sensors_.push_back(ps);
 
-  // Schedule this sensor’s periodic query
-  // It doens't need to be added to loop it is added here for every sensor configured
+  // Schedule this sensor's periodic query.
+  // The periodic interval just appends the sensor ID to the pending queue;
+  // the actual 0x17 frame is dispatched serially from drain_sensor_query_queue_()
+  // so that short-form 0x1A replies (which carry no sensor ID) can be
+  // attributed unambiguously to the most recently sent query.
   if (interval_ms > 0) {
     this->set_interval(interval_ms, [this, id]() {
-      // Light back-pressure: avoid growing queue if it’s already busy
-      if (this->write_queue_.size() < 3) {
-        this->send_sensor_query(id);  // enqueue; loop() will handle bus timing
+      if (this->pending_count_ >= MAX_PENDING_SENSOR_QUERIES) {
+        ESP_LOGW(TAG, "Sensor query queue full; dropping query for 0x%02X", id);
+        return;
       }
+      // Skip if this sensor is already pending — the next interval will retry.
+      constexpr uint8_t mask = MAX_PENDING_SENSOR_QUERIES - 1;
+      for (uint8_t i = 0; i < this->pending_count_; i++) {
+        if (this->pending_sensor_queries_[(this->pending_head_ + i) & mask] == id) return;
+      }
+      const uint8_t tail = (this->pending_head_ + this->pending_count_) & mask;
+      this->pending_sensor_queries_[tail] = id;
+      this->pending_count_++;
     });
   }
   
@@ -621,6 +652,21 @@ void ToshibaAbClimate::send_sensor_query(uint8_t sensor_id) {
 
 
   this->send_command(cmd);  // enqueue; loop() will transmit when idle
+}
+
+
+void ToshibaAbClimate::drain_sensor_query_queue_() {
+  // sensor_query_outstanding_ is cleared by process_sensor_value_() on a
+  // matching reply, or by the 1s timeout watchdog if a reply never
+  // arrives — so a stuck query never deadlocks the queue.
+  if (this->sensor_query_outstanding_) return;
+  if (this->pending_count_ == 0) return;
+  if (this->write_queue_.size() >= WRITE_QUEUE_THROTTLE) return;
+
+  const uint8_t next = this->pending_sensor_queries_[this->pending_head_];
+  this->pending_head_ = (this->pending_head_ + 1) & (MAX_PENDING_SENSOR_QUERIES - 1);
+  this->pending_count_--;
+  this->send_sensor_query(next);
 }
 
 
@@ -889,9 +935,14 @@ void ToshibaAbClimate::dump_config() {
   ESP_LOGCONFIG(TAG, "  Master address auto: %s", this->master_address_auto_ ? "true" : "false");
   ESP_LOGCONFIG(TAG, "  Command mode read: 0x%02X", this->command_mode_read_);
   ESP_LOGCONFIG(TAG, "  Command mode write: 0x%02X", this->command_mode_write_);
-  ESP_LOGCONFIG(TAG, "  Frame format: %s",
-                this->data_reader.frame_format() == FrameFormat::A0 ? "A0-protocol" :
-                this->data_reader.frame_format() == FrameFormat::TU2C ? "TU2C (U series)" : "TCC-Link");
+  const char *fmt_label;
+  switch (this->data_reader.frame_format()) {
+    case FrameFormat::TU2C: fmt_label = "TU2C (U series)"; break;
+    case FrameFormat::A0: fmt_label = "A0-protocol"; break;
+    case FrameFormat::HM: fmt_label = "HM (RAV-RM/HM range)"; break;
+    default: fmt_label = "TCC-Link"; break;
+  }
+  ESP_LOGCONFIG(TAG, "  Frame format: %s", fmt_label);
   ESP_LOGCONFIG(TAG, "  Filter frames: %s", this->filter_frames_ ? "true" : "false");
   ESP_LOGCONFIG(TAG, "  Autonomous mode: %s", this->autonomous_ ? "true" : "false");
   ESP_LOGCONFIG(TAG, "  Read only: %s", this->read_only_ ? "true" : "false");
@@ -1152,7 +1203,7 @@ void ToshibaAbClimate::process_received_data(const struct DataFrame *frame) {
           sync_from_received_state();
 
           break;
-        case OPCODE_STATUS:
+        case OPCODE_STATUS: {
           // sync power, mode, fan and target temp from the unit to the climate
           // component
 
@@ -1171,16 +1222,19 @@ void ToshibaAbClimate::process_received_data(const struct DataFrame *frame) {
 
           ESP_LOGD(TAG, "Power: %d, Mode: %02X, Fan: %02X, Vent: %02X, Target Temp: %.1f",
                    tcc_state.power, tcc_state.mode, tcc_state.fan, tcc_state.vent, tcc_state.target_temp);
-   
+
 
           sync_from_received_state();
 
           break;
-        case OPCODE_EXTENDED_STATUS:
+        }
+        case OPCODE_EXTENDED_STATUS: {
           // sync power, mode, fan and target temp from the unit to the climate
           // component
 
           log_data_frame("EXTENDED STATUS", frame);
+
+          constexpr uint8_t rt_off = STATUS_DATA_TARGET_TEMP_BYTE + 1;
 
           tcc_state.power = (frame->data[STATUS_DATA_MODEPOWER_BYTE] & STATUS_DATA_POWER_MASK);
           tcc_state.mode =
@@ -1194,10 +1248,9 @@ void ToshibaAbClimate::process_received_data(const struct DataFrame *frame) {
                   TEMPERATURE_CONVERSION_RATIO -
               TEMPERATURE_CONVERSION_OFFSET;
 
-          
-          if (frame->data[STATUS_DATA_TARGET_TEMP_BYTE + 1] > 1) {
+          if (frame->data_length > rt_off && frame->data[rt_off] > 1) {
             tcc_state.room_temp =
-                static_cast<float>(frame->data[STATUS_DATA_TARGET_TEMP_BYTE + 1]) / TEMPERATURE_CONVERSION_RATIO -
+                static_cast<float>(frame->data[rt_off]) / TEMPERATURE_CONVERSION_RATIO -
                 TEMPERATURE_CONVERSION_OFFSET;
           }
 
@@ -1210,6 +1263,7 @@ void ToshibaAbClimate::process_received_data(const struct DataFrame *frame) {
           sync_from_received_state();
 
           break;
+        }
         case OPCODE_SENSOR_VALUE:
             // sensor value received from master
           this->process_sensor_value_(frame);
@@ -1868,14 +1922,18 @@ bool ToshibaAbClimate::receive_data_frame(const struct DataFrame *frame) {
     return true;
   }
   if (!frame->is_tu2c() && frame->crc() != frame->calculate_crc()) {
-    ESP_LOGW(TAG, "CRC check failed");
-    log_data_frame("Failed frame", frame);
-
     if (this->failed_crcs_sensor_ != nullptr) {
       this->failed_crcs_sensor_->publish_state(this->failed_crcs_sensor_->state + 1);
     }
-
-    return false;
+    // Classic TCC-Link: the XOR CRC is the unit's actual algorithm, so a
+    // mismatch means the frame is corrupt — drop it. The HM variant uses
+    // a different (still-undecoded) CRC algorithm, so every frame fails
+    // the XOR check by design; tolerate the mismatch and process anyway.
+    if (!this->is_hm_variant()) {
+      ESP_LOGW(TAG, "CRC check failed");
+      log_data_frame("Failed frame", frame);
+      return false;
+    }
   }
   // >>> Drop our own TX echo frames (remote-labeled, identical bytes)
   if (this->is_own_tx_echo_(frame)) {
@@ -1899,6 +1957,11 @@ bool ToshibaAbClimate::receive_data_frame(const struct DataFrame *frame) {
 void ToshibaAbClimate::loop() {
   // TODO: check if last_unconfirmed_command_ was not confirmed after a timeout
   // and log warning/error
+
+  // Drain the pending sensor-query queue at most one per loop iteration.
+  // This must run BEFORE the TX dispatch below so an enqueued 0x17 has a
+  // chance to be picked up in the same tick.
+  this->drain_sensor_query_queue_();
 
   const bool bus_can_send = (millis() - last_received_frame_millis_) >= FRAME_SEND_MILLIS_FROM_LAST_RECEIVE &&
                             (millis() - last_sent_frame_millis_) >= FRAME_SEND_MILLIS_FROM_LAST_SEND;
@@ -2196,7 +2259,7 @@ std::vector<DataFrame> ToshibaAbClimate::create_commands(const struct TccState *
       write_set_parameter_flags_tu2c(&command, this->tu2c_remote_address_, this->tu2c_master_address_, new_state,
                                         COMMAND_SET_FAN);
     } else {
-      write_set_parameter_flags(&command, this->master_address_, this->command_mode_read_, new_state, COMMAND_SET_FAN);
+      write_set_parameter_flags(&command, this->master_address_, this->command_mode_read_, new_state, COMMAND_SET_FAN, this->is_hm_variant());
     }
     commands.push_back(command);
   }
@@ -2208,7 +2271,7 @@ std::vector<DataFrame> ToshibaAbClimate::create_commands(const struct TccState *
       write_set_parameter_flags_tu2c(&command, this->tu2c_remote_address_, this->tu2c_master_address_, new_state,
                                         COMMAND_SET_TEMP);
     } else {
-      write_set_parameter_flags(&command, this->master_address_, this->command_mode_read_, new_state, COMMAND_SET_TEMP);
+      write_set_parameter_flags(&command, this->master_address_, this->command_mode_read_, new_state, COMMAND_SET_TEMP, this->is_hm_variant());
     }
     commands.push_back(command);
   }

--- a/components/toshiba_ab/toshiba_ab.h
+++ b/components/toshiba_ab/toshiba_ab.h
@@ -6,6 +6,7 @@
 #include "esphome/components/switch/switch.h"
 #include "esphome/components/uart/uart.h"
 #include <algorithm>
+#include <array>
 #include <bitset>
 #include <cctype>
 #include <queue>
@@ -38,6 +39,7 @@ const uint8_t OPCODE_STATUS = 0x1C;
 const uint8_t OPCODE_TEMPERATURE = 0x55;
 const uint8_t OPCODE_EXTENDED_STATUS = 0x58;
 
+// Classic TCC-Link STATUS / EXTENDED_STATUS data byte offsets.
 const uint8_t STATUS_DATA_MODEPOWER_BYTE = 2;
 const uint8_t STATUS_DATA_POWER_MASK = 0b00000001;
 const uint8_t STATUS_DATA_MODE_MASK = 0b11100000;
@@ -263,10 +265,31 @@ enum class FrameFormat : uint8_t {
   NORMAL = 0,
   TU2C = 1,
   A0 = 2,
+  // HM-range dialect (RAV-RM/HM indoors paired with TU2C-Link-capable
+  // outdoors). On-wire layout for master broadcasts and remote→master
+  // frames is:
+  //
+  //   A0 00 OPCODE LEN <00 [src_mode] SRC [dst_mode] DST 00> opcode2 ... CRC
+  //
+  // The 6-byte interlude `00 [src_mode] SRC [dst_mode] DST 00` lives at
+  // wire offsets 4..9 and embeds the source and destination addresses
+  // at offsets 6 and 8 respectively. SRC=0x00 master / 0x40 remote /
+  // 0xFE broadcast — the same identifiers as classic TCC-Link, just at
+  // different byte positions. The reader normalises HM frames to the
+  // standard `src dst opcode len opcode2 ... crc` layout in put(), so
+  // the rest of the pipeline (status decoding, ACK matching, master
+  // detection) works unchanged.
+  //
+  // CRC is not validated for HM frames — the algorithm hasn't been
+  // derived (see makusets/esphome-toshiba-ab#76). Frames are accepted
+  // unconditionally and crc_valid is set to false so callers can
+  // distinguish if needed.
+  HM = 3,
 };
 constexpr FrameFormat NORMAL = FrameFormat::NORMAL;
 constexpr FrameFormat TU2C = FrameFormat::TU2C;
 constexpr FrameFormat A0 = FrameFormat::A0;
+constexpr FrameFormat HM = FrameFormat::HM;
 
 struct DataFrameReader {
   // Reads a data frame byte by byte, accumulating bytes until a complete frame is received
@@ -488,8 +511,56 @@ struct DataFrameReader {
     // If we know how many bytes we expect, finish only when we have them all
     if (expected_total_ > 0 && data_index_ >= expected_total_) {
       if (!use_tu2c) {
-        // We have the whole frame (header + payload + CRC)
-        crc_valid = frame.validate_crc();
+        // We have the whole frame (header + payload + CRC).
+        //
+        // HM dialect: master broadcasts and remote→master frames arrive
+        // with an A0:00 sync delimiter and a 6-byte interlude that
+        // embeds the real source/dest at wire offsets 6 and 8. Canonicalise
+        // in place so the rest of the pipeline sees the standard layout
+        // `src dst opcode len opcode2 PAD payload ... crc`. Sensor-reply
+        // frames (e.g. 00:40:1A:...) lack the A0:00 prefix and are passed
+        // through unchanged.
+        //
+        // We strip the 6-byte HM wrapper (wire offsets 4..9) and then
+        // inject a single 0x00 padding byte right after opcode2 so the
+        // mode/power, fan/vent, flags and target_temp bytes land at
+        // exactly the same data[] offsets as classic TCC-Link
+        // (STATUS_DATA_*_BYTE constants). Net change to the frame size
+        // is therefore −5 bytes (strip 6 wrapper + insert 1 padding).
+        if (frame_format_ == FrameFormat::HM
+            && frame.raw[0] == 0xA0 && frame.raw[1] == 0x00
+            && frame.data_length >= 7) {
+          const uint16_t total = expected_total_;
+          const uint8_t crc_byte = frame.raw[total - 1];
+          const uint8_t new_src = frame.raw[6];
+          const uint8_t new_dst = frame.raw[8];
+          const uint8_t new_data_length = frame.data_length - 5;
+          const uint8_t opcode2 = frame.raw[10];
+          // Real payload after opcode2 in the wire frame is
+          // (data_length - 7) bytes, located at wire raw[11..total-2].
+          const uint8_t tail_len = frame.data_length - 7;
+          // raw[4] = opcode2, raw[5] = 0x00 padding, raw[6..] = tail.
+          // Source range raw[11..] is to the RIGHT of destination range
+          // raw[6..]; iterate forward so each source byte is read before
+          // any subsequent write could overwrite it.
+          for (uint8_t i = 0; i < tail_len; i++) {
+            frame.raw[DATA_OFFSET_FROM_START + 2 + i] = frame.raw[11 + i];
+          }
+          frame.raw[DATA_OFFSET_FROM_START + 0] = opcode2;
+          frame.raw[DATA_OFFSET_FROM_START + 1] = 0x00;
+          frame.raw[0] = new_src;
+          frame.raw[1] = new_dst;
+          // raw[2] (opcode1) is at the same wire offset in HM as in
+          // NORMAL; only the length value changes.
+          frame.raw[3] = new_data_length;
+          frame.data_length = new_data_length;
+          frame.raw[DATA_OFFSET_FROM_START + new_data_length] = crc_byte;
+          // CRC algorithm for HM hasn't been derived yet — accept the
+          // frame but flag the CRC as unvalidated so callers can decide.
+          crc_valid = false;
+        } else {
+          crc_valid = frame.validate_crc();
+        }
         complete  = true;
 
         // Prepare reader for the next frame
@@ -569,7 +640,7 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
   void dump_config() override;
   void setup() override;
   void loop() override;
-  
+
   uint8_t master_address_ = 0x00;
   bool master_address_auto_{true};
   uint8_t tu2c_remote_address_{TOSHIBA_TU2C_REMOTE_DEFAULT};
@@ -594,8 +665,7 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
   void set_backup_heater_hours_sensor(sensor::Sensor *sensor) { backup_heater_hours_sensor_ = sensor; }
   void set_demand_sensor(sensor::Sensor *sensor) { demand_sensor_ = sensor; }
   void set_frame_format(FrameFormat format) { data_reader.set_frame_format(format); }
-
-
+  bool is_hm_variant() const { return data_reader.frame_format() == FrameFormat::HM; }
 
   climate::ClimateTraits traits() override;
   void control(const climate::ClimateCall &call) override;
@@ -714,6 +784,26 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
   uint32_t last_sensor_query_ms_{0};
   uint32_t sensor_query_timeout_ms_{1000};  // 3s default; adjust if needed
   uint32_t sensor_query_timeouts_{0};       // (optional) stats
+
+  // Pending-query ring buffer. Periodic intervals push sensor IDs here;
+  // the loop drains one at a time once the previous query has been
+  // answered (or timed out). Strict serialisation prevents the response
+  // misattribution that occurs when multiple short-form 0x1A replies
+  // (which carry no sensor ID) collide with a back-to-back set of 0x17
+  // queries. Capacity is a power of two so head advancement uses a
+  // bitmask instead of modulo. Fixed std::array (vs std::deque) keeps
+  // it on the object — zero heap, ~18 bytes total.
+  static constexpr size_t MAX_PENDING_SENSOR_QUERIES = 16;
+  static_assert((MAX_PENDING_SENSOR_QUERIES & (MAX_PENDING_SENSOR_QUERIES - 1)) == 0,
+                "MAX_PENDING_SENSOR_QUERIES must be a power of two");
+  std::array<uint8_t, MAX_PENDING_SENSOR_QUERIES> pending_sensor_queries_{};
+  uint8_t pending_head_{0};
+  uint8_t pending_count_{0};
+  // TX back-pressure threshold reused from the original sensor-query
+  // gating; sensor queries are throttled when the write queue is this
+  // deep so we don't pile commands behind a slow bus.
+  static constexpr size_t WRITE_QUEUE_THROTTLE = 3;
+  void drain_sensor_query_queue_();
 
   // room temperature sensor reporting to AC  ******************************
   sensor::Sensor *ext_temp_sensor_{nullptr};


### PR DESCRIPTION
**Draft / WIP — opening for early feedback on the approach before polishing.**

Companion to issue #76. Adds an opt-in `protocol_variant` YAML option (`classic` default | `hm`) so HM-range indoor units (RAV-RM801BTP-E and similar, paired with TU2C-Link-capable outdoors like RAV-GM801ATP-E) can use this component. Classic TCC-Link behaviour is unchanged when the flag is not set.

## Why

My RAV-RM801BTP-E + RAV-GM801ATP-E + RBC-ASCU11-E setup speaks a TCC-Link variant that differs from the existing decoder in four concrete ways. Without these adjustments, every broadcast frame is dropped at the CRC gate, the few that pass go to the "unknown source" branch, and HA-driven temp/fan commands are silently rejected by the AC. The differences look small enough to live in the existing component behind a flag rather than as a separate codepath.

## Empirical findings (HM variant vs classic)

| Aspect | Classic TCC-Link | HM variant |
|---|---|---|
| Master broadcast source byte | unicast master addr (e.g. `0x00`) | **`0xA0`** |
| STATUS `mode/power` offset | data[2] (raw[6]) | **data[7] (raw[11])** |
| STATUS `fan/vent` offset | data[3] (raw[7]) | **data[8] (raw[12])** |
| STATUS `target_temp` offset | data[6] (raw[10]) | **data[11] (raw[15])** |
| STATUS `room_temp` offset | target+1 | **data[19] (raw[23])** *(best guess pending more data)* |
| SET_TEMP_WITH_FAN payload | 6 bytes | **9 bytes** (3 trailing zeros) |
| CRC algorithm | XOR all bytes | **unknown non-XOR** (tolerated, not validated) |
| Temperature encoding | `byte/2 − 35` | same |
| Wire envelope (`A0:XX:LEN:OPCODE:...:CRC`) | same | same |

Confirmed empirically: setting target to 22 °C produces `raw[15] = 0x72`, and `(0x72 / 2) − 35 = 22 °C` exactly. The first six bytes of the SET_TEMP_WITH_FAN payload match what the existing logic produces; only the trailing `00:00:00` was missing — without it the AC's controller silently ignores the command (master ACKs because envelope is valid, but the controller doesn't act on it).

Captured from the RBC-ASCU11-E wired remote pressing temp-down at 22 °C (Cool):
```
A0:00:11:10:00:00:40:08:00:00:4C:0A:1A:72:00:33:33:00:00:00:8F
                              opcode^^ payload(9 bytes)
```

## Implementation

- New `enum class ProtocolVariant { CLASSIC, HM }` at namespace scope.
- New member `protocol_variant_` + setter `set_protocol_variant()`.
- New `STATUS_DATA_*_BYTE_HM` constants alongside the existing classic ones.
- Per-variant accessors `status_modepower_offset()`, `status_fanvent_offset()`, `status_flags_offset()`, `status_target_temp_offset()`, `status_room_temp_offset()` used in `OPCODE_STATUS`, `OPCODE_EXTENDED_STATUS`, and `OPCODE_PARAMETER` handlers.
- `process_received_data()` accepts `0xA0` as master only when `is_hm_variant()`.
- `receive_data_frame()` drops CRC-mismatched frames in classic mode (unchanged) but tolerates them in HM mode.
- `write_set_parameter_flags()` takes a new `bool hm_variant` parameter and emits the longer payload accordingly.
- `dump_config()` now logs the active variant.
- Python schema adds `protocol_variant: classic | hm` (default `classic`) wired through to_code.

## Status

**Working** on my unit:
- HA-side state readback (mode, power, fan, target temp) ✅
- HA-side temp/mode/power control ✅
- 7 polled diagnostic sensors (compressor freq, outdoor/coil temps, fan RPM, hours) ✅

**Known gaps** (acknowledging to set expectations):
- `STATUS_DATA_ROOM_TEMP_BYTE_HM = 19` is a best-guess from plausible byte values; needs experiments at known room temps to confirm.
- The HM CRC algorithm isn't derived. Brute-forced 67M combinations of standard CRC-8 parameters across 20 captured frames; no match. Likely covers a non-trivial subset of bytes or is non-standard. The `failed_crcs_sensor` still increments so users can see frame counts; tolerance is the workaround.
- `0x1A` (sensor-value) replies in this variant don't match either of the existing short/long patterns — sensor queries respond but aren't decoded. Not addressed here.
- Mode/fan offset shifts are inferred (consistent with target_temp's +5 shift and decoded values that match observed AC state); haven't run a power-cycle / mode-cycle experiment to bit-prove. No regressions observed.

## Test plan

- [x] Compiles cleanly for esp8266 with the HM flag set
- [x] Decodes STATUS / EXTENDED_STATUS / MASTER PARAMETERS / ACK / PING on RAV-RM801BTP-E
- [x] HA temp slider applies to AC; mode change applies; power on/off applies
- [x] No regressions for classic TCC-Link path *(unchanged when flag is default)*
- [ ] Power-cycle / mode-cycle experiments to nail down room_temp offset and confirm bit-level mode encoding
- [ ] CRC algorithm derivation (out of scope here; tracked in #76)
- [ ] Test on a classic TCC-Link unit with `protocol_variant: classic` to confirm behaviour didn't drift *(would appreciate a second pair of eyes here)*

## Questions for you

1. Is opt-in flag the right shape, or would you prefer auto-detection (e.g. seeing `0xA0`-source frames during the first N seconds of operation)?
2. Naming: `protocol_variant: hm` vs something more descriptive (`hm_link`, `tu2c_hm`)? I went with `hm` since it matches Toshiba's own product-range naming, but happy to change.
3. CRC tolerance: currently tolerated with the `failed_crcs_sensor` still incrementing. Acceptable as a stopgap, or would you prefer a hard error / different escape hatch?

Happy to iterate. Raising as draft so we can align on direction before I polish.