### PR TITLE
Add TU2C-specific timing and retry logic for command ACKs

### DIFF
--- a/components/toshiba_ab/toshiba_ab.cpp
+++ b/components/toshiba_ab/toshiba_ab.cpp
@@ -247,10 +247,15 @@ void ToshibaAbClimate::handle_pending_command_ack_(const DataFrame *frame) {
     this->last_unconfirmed_command_.reset();
     this->last_unconfirmed_command_attempts_ = 0;
     this->resend_last_unconfirmed_command_ = false;
+    this->last_unconfirmed_command_sent_ms_ = 0;
     return;
   }
 
-  this->resend_last_unconfirmed_command_ = true;
+  // TU2C retries are timeout-driven. Keep legacy immediate retry behaviour
+  // for non-TU2C traffic unchanged.
+  if (!this->last_unconfirmed_command_->is_tu2c()) {
+    this->resend_last_unconfirmed_command_ = true;
+  }
 }
 
 void log_data_frame(const std::string msg, const struct DataFrame *frame, size_t length = 0) {
@@ -1969,25 +1974,34 @@ void ToshibaAbClimate::loop() {
   if (bus_can_send) {
     optional<DataFrame> frame_to_send{};
 
-    if (this->resend_last_unconfirmed_command_ && this->last_unconfirmed_command_.has_value()) {
-      if (this->last_unconfirmed_command_attempts_ >= MAX_COMMAND_SEND_ATTEMPTS) {
+    if (this->last_unconfirmed_command_.has_value()) {
+      const bool pending_is_tu2c = this->last_unconfirmed_command_->is_tu2c();
+      const bool retry_due = pending_is_tu2c
+                                 ? (this->last_unconfirmed_command_sent_ms_ != 0 &&
+                                    (millis() - this->last_unconfirmed_command_sent_ms_) >= TU2C_ACK_TIMEOUT_MS)
+                                 : this->resend_last_unconfirmed_command_;
+      const uint8_t max_attempts = pending_is_tu2c ? TU2C_MAX_COMMAND_SEND_ATTEMPTS : MAX_COMMAND_SEND_ATTEMPTS;
+      if (retry_due) {
+        if (this->last_unconfirmed_command_attempts_ >= max_attempts) {
         ESP_LOGE(TAG, "Command opcode 0x%02X not acknowledged after %u attempts", this->last_unconfirmed_command_->opcode1,
                  static_cast<unsigned>(this->last_unconfirmed_command_attempts_));
         this->last_unconfirmed_command_.reset();
         this->last_unconfirmed_command_attempts_ = 0;
         this->resend_last_unconfirmed_command_ = false;
-      } else {
-        frame_to_send = this->last_unconfirmed_command_.value();
-        this->last_unconfirmed_command_attempts_++;
-        this->resend_last_unconfirmed_command_ = false;
-        if (frame_to_send->is_tu2c()) {
-          ESP_LOGD(TAG, "Resending TU2C command (attempt %u/%u)",
-                   static_cast<unsigned>(this->last_unconfirmed_command_attempts_),
-                   static_cast<unsigned>(MAX_COMMAND_SEND_ATTEMPTS));
+        this->last_unconfirmed_command_sent_ms_ = 0;
         } else {
-          ESP_LOGD(TAG, "Resending command opcode 0x%02X (attempt %u/%u)", frame_to_send->opcode1,
-                   static_cast<unsigned>(this->last_unconfirmed_command_attempts_),
-                   static_cast<unsigned>(MAX_COMMAND_SEND_ATTEMPTS));
+          frame_to_send = this->last_unconfirmed_command_.value();
+          this->last_unconfirmed_command_attempts_++;
+          this->resend_last_unconfirmed_command_ = false;
+          if (frame_to_send->is_tu2c()) {
+            ESP_LOGD(TAG, "Resending TU2C command after ACK timeout (attempt %u/%u)",
+                     static_cast<unsigned>(this->last_unconfirmed_command_attempts_),
+                     static_cast<unsigned>(max_attempts));
+          } else {
+            ESP_LOGD(TAG, "Resending command opcode 0x%02X (attempt %u/%u)", frame_to_send->opcode1,
+                     static_cast<unsigned>(this->last_unconfirmed_command_attempts_),
+                     static_cast<unsigned>(max_attempts));
+          }
         }
       }
     }
@@ -2024,15 +2038,28 @@ void ToshibaAbClimate::loop() {
         this->last_unconfirmed_command_ = frame_to_send.value();
         this->last_unconfirmed_command_attempts_ = 1;
         this->resend_last_unconfirmed_command_ = false;
+        this->last_unconfirmed_command_sent_ms_ = millis();
       } else {
         this->last_unconfirmed_command_.reset();
         this->last_unconfirmed_command_attempts_ = 0;
         this->resend_last_unconfirmed_command_ = false;
+        this->last_unconfirmed_command_sent_ms_ = 0;
       }
     }
 
     if (frame_to_send.has_value()) {
+      if (frame_to_send->is_tu2c()) {
+        const bool tu2c_timing_ok =
+            (millis() - last_tu2c_received_frame_millis_) >= TU2C_FRAME_SEND_MILLIS_FROM_LAST_RECEIVE &&
+            (millis() - last_tu2c_sent_frame_millis_) >= TU2C_FRAME_SEND_MILLIS_FROM_LAST_SEND;
+        if (!tu2c_timing_ok) {
+          return;
+        }
+      }
       last_sent_frame_millis_ = millis();
+      if (frame_to_send->is_tu2c()) {
+        last_tu2c_sent_frame_millis_ = last_sent_frame_millis_;
+      }
       auto frame = frame_to_send.value();
       log_data_frame("Write frame", &frame);
       this->remember_tx_frame_for_echo_(frame.raw, frame.size(), frame.is_tu2c());
@@ -2144,6 +2171,9 @@ void ToshibaAbClimate::loop() {
         last_received_frame_millis_ = millis();
 
         auto frame = data_reader.frame;
+        if (frame.is_tu2c()) {
+          last_tu2c_received_frame_millis_ = last_received_frame_millis_;
+        }
 
         if (!receive_data_frame(&frame)) {
         }

--- a/components/toshiba_ab/toshiba_ab.h
+++ b/components/toshiba_ab/toshiba_ab.h
@@ -832,16 +832,23 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
 
   uint32_t last_received_frame_millis_ = 0;
   uint32_t last_sent_frame_millis_ = 0;
+  uint32_t last_tu2c_received_frame_millis_ = 0;
+  uint32_t last_tu2c_sent_frame_millis_ = 0;
   std::queue<DataFrame> write_queue_;
   std::queue<std::vector<uint8_t>> raw_write_queue_;
   optional<DataFrame> last_unconfirmed_command_;
   uint8_t last_unconfirmed_command_attempts_{0};
   bool resend_last_unconfirmed_command_{false};
+  uint32_t last_unconfirmed_command_sent_ms_{0};
   optional<DataFrame> last_tx_frame_for_echo_;
   uint32_t last_tx_frame_millis_{0};
   static const uint32_t ECHO_MATCH_WINDOW_MS = 1500;
 
   static const uint8_t MAX_COMMAND_SEND_ATTEMPTS = 5;
+  static const uint8_t TU2C_MAX_COMMAND_SEND_ATTEMPTS = 3;
+  static const uint32_t TU2C_ACK_TIMEOUT_MS = 3000;
+  static const uint32_t TU2C_FRAME_SEND_MILLIS_FROM_LAST_RECEIVE = 500;
+  static const uint32_t TU2C_FRAME_SEND_MILLIS_FROM_LAST_SEND = 500;
 
   // Estia raw command ACK tracking
   std::vector<uint8_t> estia_pending_cmd_;        // last sent raw command (for retry)


### PR DESCRIPTION
### Motivation
- TU2C traffic requires different ACK semantics and stricter inter-frame timing than legacy frames, so retries must be timeout-driven to avoid immediate collisions.
- The code needs to track TU2C-specific send/receive timestamps to enforce spacing constraints when sending TU2C frames.
- Ensure retry limits and logging reflect different maximum attempts for TU2C versus non-TU2C commands.

### Description
- Added TU2C-specific member variables `last_tu2c_received_frame_millis_`, `last_tu2c_sent_frame_millis_`, and `last_unconfirmed_command_sent_ms_` to track timing of TU2C frames and pending command send time.  
- Introduced constants `TU2C_MAX_COMMAND_SEND_ATTEMPTS`, `TU2C_ACK_TIMEOUT_MS`, `TU2C_FRAME_SEND_MILLIS_FROM_LAST_RECEIVE`, and `TU2C_FRAME_SEND_MILLIS_FROM_LAST_SEND` to configure TU2C retry/timeouts and inter-frame spacing.  
- Modified `handle_pending_command_ack_` to avoid immediate retry for TU2C frames and to clear `last_unconfirmed_command_sent_ms_` on ACK.  
- Reworked `loop()` send logic to: compute separate retry timing and attempt limits for TU2C vs non-TU2C pending commands, set `last_unconfirmed_command_sent_ms_` when enqueuing a tracked command, enforce TU2C inter-frame timing before sending, and update TU2C send/receive timestamps when sending/receiving TU2C frames.  
- Kept legacy immediate-retry behavior for non-TU2C traffic and added more descriptive logging around TU2C retry attempts.  

### Testing
- Performed a local project build with `platformio run`, which completed successfully.  
- Verified the code compiles cleanly on the target environment and no new compile errors were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d49a236fc832f89e8ab4a500217b7)