### PR TITLE
Ignore STATUS/EXTENDED_STATUS frames unless `raw[5] == 0x81`

### DIFF
--- a/components/toshiba_ab/toshiba_ab.cpp
+++ b/components/toshiba_ab/toshiba_ab.cpp
@@ -1211,6 +1211,10 @@ void ToshibaAbClimate::process_received_data(const struct DataFrame *frame) {
         case OPCODE_STATUS: {
           // sync power, mode, fan and target temp from the unit to the climate
           // component
+          if (frame->size() <= 5 || frame->raw[5] != 0x81) {
+            log_data_frame("STATUS ignored (raw[5] != 0x81)", frame);
+            break;
+          }
 
           log_data_frame("STATUS", frame);
 
@@ -1236,6 +1240,10 @@ void ToshibaAbClimate::process_received_data(const struct DataFrame *frame) {
         case OPCODE_EXTENDED_STATUS: {
           // sync power, mode, fan and target temp from the unit to the climate
           // component
+          if (frame->size() <= 5 || frame->raw[5] != 0x81) {
+            log_data_frame("EXTENDED STATUS ignored (raw[5] != 0x81)", frame);
+            break;
+          }
 
           log_data_frame("EXTENDED STATUS", frame);
 


### PR DESCRIPTION
### Motivation
- Prevent processing of unexpected or malformed `OPCODE_STATUS` and `OPCODE_EXTENDED_STATUS` frames by filtering on `frame->size()` and the value of `frame->raw[5]`.

### Description
- Add checks in `ToshibaAbClimate::process_received_data` to log and ignore `STATUS` and `EXTENDED_STATUS` frames when `frame->size() <= 5` or `frame->raw[5] != 0x81`, preserving existing state parsing and `sync_from_received_state()` for valid frames.

### Testing
- Performed a project build and ran the existing automated unit tests and integration checks; the build succeeded and tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e35f27f24832f9a915fb1549f8ca9)