### PR TITLE
Decode additional remote parameter commands

### DIFF
--- a/components/toshiba_ab/toshiba_ab.cpp
+++ b/components/toshiba_ab/toshiba_ab.cpp
@@ -1353,6 +1353,18 @@ void ToshibaAbClimate::process_received_data(const struct DataFrame *frame) {
                 
         log_data_frame("Remote Timer Read", frame);
 
+      } else if (frame->opcode1 == OPCODE_PARAMETER &&
+                 frame->data_length >= 3) {
+        // Remote command frames (opcode1 0x11)
+        if (frame->data[1] == 0x4C) {
+          log_data_frame("Remote command: fan/mode/temp change", frame);
+        } else if (frame->data[1] == 0x41 && frame->data[2] == 0x02) {
+          log_data_frame("Remote command: power off", frame);
+        } else if (frame->data[1] == 0x41 && frame->data[2] == 0x03) {
+          log_data_frame("Remote command: power off", frame);
+        } else {
+          log_data_frame("Remote command", frame);
+        }
       } else {
         // unknown remote message
         log_data_frame("Unknown remote data", frame);


### PR DESCRIPTION
### Motivation
- Report and classify remote-origin normal parameter frames (`opcode1 == 0x11`) as explicit remote commands so specific remote actions can be observed and handled. 

### Description
- Added a branch in `ToshibaAbClimate::process_received_data` to detect `frame->opcode1 == OPCODE_PARAMETER` with `frame->data_length >= 3`. 
- Classify `frame->data[1] == 0x4C` as `"Remote command: fan/mode/temp change"`. 
- Classify `frame->data[1] == 0x41 && frame->data[2] == 0x02` and `frame->data[1] == 0x41 && frame->data[2] == 0x03` as `"Remote command: power off"`. 
- Provide a generic `"Remote command"` fallback and preserve the existing unknown-remote handling. 

### Testing
- No automated test suite was run for this change. 
- Verified the inserted code block via `nl -ba components/toshiba_ab/toshiba_ab.cpp | sed -n '1338,1398p'`. 
- Performed repository text search to confirm `process_received_data` references were located and updated as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e50afd218832f9cc3638dd1d0cc1d)