### PR TITLE
Treat 0x40–0x49 frame sources as remote in receive path

### DIFF
--- a/components/toshiba_ab/toshiba_ab.cpp
+++ b/components/toshiba_ab/toshiba_ab.cpp
@@ -1312,7 +1312,9 @@ void ToshibaAbClimate::process_received_data(const struct DataFrame *frame) {
           break;
       }
     }else {
-    if (frame->source == this->remote_address_) {
+    const bool is_remote_source = (frame->source == this->remote_address_) ||
+                                  (frame->source >= 0x40 && frame->source <= 0x49);
+    if (is_remote_source) {
       ESP_LOGD(TAG, "Received data from remote:");
 
       // Remote temperature push: 40 00 55 05 08 81 01 6E 00 ..


### PR DESCRIPTION
### Motivation
- Some valid remote-origin frames use source IDs in the range `0x40..0x49` and were being classified as unknown sources instead of being handled by the remote logic.

### Description
- In `components/toshiba_ab/toshiba_ab.cpp` the remote-source check was replaced with `const bool is_remote_source = (frame->source == this->remote_address_) || (frame->source >= 0x40 && frame->source <= 0x49);` and the remote branch was switched to `if (is_remote_source)` so frames with sources `0x40` through `0x49` are processed by the remote handling path.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ff9efa420832f9488abb805aa3e17)