### PR TITLE
toshiba_ab: auto-address remotes, clamp remote IDs, and handle external temp frames by opcode

### DIFF
--- a/components/toshiba_ab/climate.py
+++ b/components/toshiba_ab/climate.py
@@ -123,7 +123,7 @@ REPORT_SENSOR_TEMP_SCHEMA = cv.Schema({
 CONFIG_SCHEMA = climate._CLIMATE_SCHEMA.extend(
     {
         cv.Optional(CONF_MASTER, default=0x00): cv.uint8_t,
-        cv.Optional(CONF_REMOTE, default=0x40): cv.uint8_t,
+        cv.Optional(CONF_REMOTE): cv.uint8_t,
         cv.Optional(CONF_MASTER_ADDRESS_AUTO, default=True): cv.boolean,
         cv.Optional(CONF_COMMAND_MODE_READ, default=0x08): cv.uint8_t,
         cv.Optional(CONF_COMMAND_MODE_WRITE, default=0x80): cv.uint8_t,

--- a/components/toshiba_ab/toshiba_ab.cpp
+++ b/components/toshiba_ab/toshiba_ab.cpp
@@ -493,8 +493,10 @@ void write_read_envelope(DataFrame *cmd, uint8_t remote_address, uint8_t master_
 }
 
 
-// Sends room temp to AC unit with the sensor configured in yaml
-// example frame: 42:00:11:04:08:89:72:46:E2 for 22 degrees
+// Sends room temp to AC unit with the sensor configured in yaml.
+// Uses a dedicated source address offset from the runtime remote id
+// (remote+1, capped at 0x49) to avoid colliding with normal remote traffic.
+// Example: if remote id is 0x41, this frame source becomes 0x42.
 void ToshibaAbClimate::send_remote_temp(float temp_c) {
   // sanity
   if (!std::isfinite(temp_c) || temp_c < -40.0f || temp_c > 80.0f) {
@@ -505,10 +507,11 @@ void ToshibaAbClimate::send_remote_temp(float temp_c) {
   // Encode raw = (C + OFFSET) * RATIO, mask per protocol
   const uint8_t raw = static_cast<uint8_t>(
       std::lround((temp_c + TEMPERATURE_CONVERSION_OFFSET) * TEMPERATURE_CONVERSION_RATIO));
+  const uint8_t temp_source = std::min<uint8_t>(this->remote_address_ + 1, TOSHIBA_REMOTE_MAX);
 
 
   DataFrame cmd{};
-  cmd.source      = TOSHIBA_TEMP_SENSOR;        // 0x42
+  cmd.source      = temp_source;
   cmd.dest        = this->master_address_;  // usually 0x00
   cmd.opcode1     = OPCODE_PARAMETER;       // 0x11
   cmd.data_length = 4;                       // payload: 08 89 <raw> 46
@@ -1315,6 +1318,17 @@ void ToshibaAbClimate::process_received_data(const struct DataFrame *frame) {
     const bool is_remote_source = (frame->source == this->remote_address_) ||
                                   (frame->source >= 0x40 && frame->source <= 0x49);
     if (is_remote_source) {
+      // In remote auto-address mode we start at 0x40 and avoid collisions with
+      // existing remotes on the bus. If any remote frame arrives using our
+      // current address, shift to the next address up to 0x49.
+      if (this->remote_address_auto_ &&
+          frame->source == this->remote_address_ &&
+          this->remote_address_ < TOSHIBA_REMOTE_MAX) {
+        const uint8_t old = this->remote_address_;
+        this->remote_address_++;
+        ESP_LOGI(TAG, "Remote auto-address collision detected at 0x%02X; switching to 0x%02X",
+                 old, this->remote_address_);
+      }
       ESP_LOGD(TAG, "Received data from remote:");
 
       // Remote temperature push: 40 00 55 05 08 81 01 6E 00 ..
@@ -1373,12 +1387,11 @@ void ToshibaAbClimate::process_received_data(const struct DataFrame *frame) {
         log_data_frame("Unknown remote data", frame);
       }
     
-    } else if (frame->source == TOSHIBA_TEMP_SENSOR) {
-      // message from configured temp sensor in yaml
-      // example:   42:00:11:04:08:89:72:46:E2  for 22 degrees, this message follows Toshiba standalone temp sensor format
-      if (frame->opcode1 == OPCODE_PARAMETER &&
-          frame->data_length == 4 &&
-          frame->data[1] == 0x89) {
+    } else if (frame->opcode1 == OPCODE_PARAMETER &&
+               frame->data_length == 4 &&
+               frame->data[1] == 0x89) {
+      // External room-temperature report frame. Do not key this on a fixed
+      // source address (e.g. 0x42), because runtime remote id can vary.
 
         std::string label = this->ext_temp_sensor_name_.empty()
                     ? "Yaml temp sensor"
@@ -1387,9 +1400,6 @@ void ToshibaAbClimate::process_received_data(const struct DataFrame *frame) {
         uint8_t raw = frame->data[2] & TEMPERATURE_DATA_MASK;  // raw[7]
         float sensor_temp = static_cast<float>(raw) / TEMPERATURE_CONVERSION_RATIO - TEMPERATURE_CONVERSION_OFFSET;
         ESP_LOGD(TAG, "%s: %.1f °C", label.c_str(), sensor_temp);
-      } else {
-        log_data_frame("Unknown 0x42 data", frame);
-      }
     } else {
     // Unknown source handling
     ESP_LOGD(TAG, "Received data from unknown source: %02X", frame->source);

--- a/components/toshiba_ab/toshiba_ab.h
+++ b/components/toshiba_ab/toshiba_ab.h
@@ -23,6 +23,7 @@ const uint32_t FRAME_SEND_MILLIS_FROM_LAST_SEND = 500;
 
 // const uint8_t TOSHIBA_MASTER = 0x00;  replaced by master_address_ which is set up in yaml
 const uint8_t TOSHIBA_REMOTE_DEFAULT = 0x40;
+const uint8_t TOSHIBA_REMOTE_MAX = 0x49;
 const uint8_t TOSHIBA_TU2C_REMOTE_DEFAULT = 0x50;
 const uint8_t TOSHIBA_TU2C_MASTER_DEFAULT = 0x90;
 const uint8_t TOSHIBA_TEMP_SENSOR = 0x42;
@@ -643,12 +644,16 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
 
   uint8_t master_address_ = 0x00;
   uint8_t remote_address_{TOSHIBA_REMOTE_DEFAULT};
+  bool remote_address_auto_{true};
   bool master_address_auto_{true};
   uint8_t tu2c_remote_address_{TOSHIBA_TU2C_REMOTE_DEFAULT};
   uint8_t tu2c_master_address_{TOSHIBA_TU2C_MASTER_DEFAULT};
   bool filter_frames_{true};
   void set_master_address(uint8_t address);
-  void set_remote_address(uint8_t address) { remote_address_ = address; }
+  void set_remote_address(uint8_t address) {
+    remote_address_ = std::min(address, TOSHIBA_REMOTE_MAX);
+    remote_address_auto_ = false;
+  }
   void set_master_address_auto(bool auto_detect) {
     master_address_auto_ = auto_detect;
   }


### PR DESCRIPTION
### Motivation
- Enable robust operation on shared TCC-Link buses by auto-selecting a non-colliding remote ID and avoiding fixed hard-coded sensor source addresses.
- Prevent out-of-range remote IDs and make explicit remote configuration disable auto-addressing.
- Accept external room-temperature reports by opcode rather than relying on a fixed source so runtime remote addressing does not break sensor reporting.

### Description
- Added `TOSHIBA_REMOTE_MAX` and a `remote_address_auto_` flag, and introduced clamping of runtime remote address to `TOSHIBA_REMOTE_MAX` in `set_remote_address()` to prevent invalid IDs.
- Implemented remote auto-address collision handling in `process_received_data()` to increment the chosen remote ID when another device uses the same address, with logging of address changes.
- Changed `send_remote_temp()` to use a dedicated source computed as `min(remote + 1, TOSHIBA_REMOTE_MAX)` instead of a fixed constant, and updated comments describing the behavior.
- Relaxed detection of external room-temperature frames to rely on opcode and payload pattern (`OPCODE_PARAMETER` with `data[1] == 0x89`) rather than a hard-coded source address so external sensor reports work with variable runtime remote IDs.
- In the Python config schema, removed the default value for `CONF_REMOTE` so explicit configuration disables auto-addressing behavior.

### Testing
- Project compiled successfully using the ESPHome/PlatformIO build (`pio run`) after the changes.
- No repository unit tests were present to run; static code path exercised by build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a104e55bef8832f807ffebceac68165)