### PR TITLE
Log remote temperature when enqueuing send_remote_temp

### DIFF
--- a/components/toshiba_ab/toshiba_ab.cpp
+++ b/components/toshiba_ab/toshiba_ab.cpp
@@ -534,6 +534,7 @@ void ToshibaAbClimate::send_remote_temp(float temp_c) {
 
   cmd.data[cmd.data_length] = cmd.calculate_crc();
 
+  ESP_LOGD(TAG, "send_remote_temp: enqueuing remote temperature %.1f°C (raw=0x%02X)", temp_c, raw);
   this->send_command(cmd);  // enqueue; loop() sends when bus is idle
 }
 


### PR DESCRIPTION
### Motivation
- Include the actual Celsius value and encoded raw byte in logs when `send_remote_temp(float temp_c)` enqueues a remote-temperature frame to aid debugging and verify what the AC receives.

### Description
- Added a debug log call `ESP_LOGD(TAG, "send_remote_temp: enqueuing remote temperature %.1f°C (raw=0x%02X)", temp_c, raw);` in `components/toshiba_ab/toshiba_ab.cpp` immediately before `send_command(cmd)`, with no other behavioral changes.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1055fce130832fb65e56b5d563a43c)