### PR TITLE
Log rounded remote temperature in send_remote_temp

### DIFF
--- a/components/toshiba_ab/toshiba_ab.cpp
+++ b/components/toshiba_ab/toshiba_ab.cpp
@@ -517,6 +517,7 @@ void ToshibaAbClimate::send_remote_temp(float temp_c) {
   // Encode raw = (C + OFFSET) * RATIO, mask per protocol
   const uint8_t raw = static_cast<uint8_t>(
       std::lround((temp_c + TEMPERATURE_CONVERSION_OFFSET) * TEMPERATURE_CONVERSION_RATIO));
+  const float rounded_temp_c = static_cast<float>(raw) / TEMPERATURE_CONVERSION_RATIO - TEMPERATURE_CONVERSION_OFFSET;
   const uint8_t temp_source = std::min<uint8_t>(this->remote_address_ + 1, TOSHIBA_REMOTE_MAX);
 
 
@@ -534,7 +535,7 @@ void ToshibaAbClimate::send_remote_temp(float temp_c) {
 
   cmd.data[cmd.data_length] = cmd.calculate_crc();
 
-  ESP_LOGD(TAG, "Sending sensor temperature: %.1f°C", temp_c);
+  ESP_LOGD(TAG, "Sending sensor temperature: %.1f°C", rounded_temp_c);
   this->send_command(cmd);  // enqueue; loop() sends when bus is idle
 }
 


### PR DESCRIPTION
### Motivation
- Ensure the debug log for `send_remote_temp()` reports the actual temperature value that is encoded and sent to the master unit (rounded to 0.5°C), so logs match on-wire behavior.

### Description
- Compute `rounded_temp_c` from the encoded payload byte and change the debug log to print `rounded_temp_c` instead of the original `temp_c` in `components/toshiba_ab/toshiba_ab.cpp` within `ToshibaAbClimate::send_remote_temp()`; payload encoding and transmission are unchanged.

### Testing
- No automated tests were executed for this small, logging-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10584dacb8832fab3d6341db96d711)