### PR TITLE
HM dialect: control reliability + WDT stability

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,49 @@ See `example_estia.yaml` for a complete configuration including optional 0-10V d
 - makusets "Toshiba AB D1 Mini" board (LMV331TP comparator)
 
 
+# Toshiba HM-range Support (RAV-RM / RAV-GM)
+
+Newer HM-range indoor units — the `RAV-RM…BTP-E` series (e.g. **RAV-RM801BTP-E**), typically paired with a TU2C-Link-capable outdoor such as the `RAV-GM…ATP-E` series (e.g. **RAV-GM801ATP-E**) — speak a dialect of the AB protocol that the classic TCC-Link decoder does not understand out of the box. This component supports it via `frame_format: hm`.
+
+The HM dialect differs from classic TCC-Link in a few ways: an `A0:00` sync delimiter wrapping the frame, source/destination addresses at different wire offsets, a longer `SET_TEMP_WITH_FAN` payload, and the `STATUS` / `EXTENDED_STATUS` marker sitting one byte earlier. The reader canonicalises HM frames to the standard in-memory layout, so the rest of the pipeline (control, sensors, etc.) behaves the same as `n`.
+
+## Features
+
+- Full control: power, mode (auto / cool / heat / dry / fan-only), fan speed, setpoint
+- Reads room temperature plus the optional diagnostic sensors (compressor frequency, operating current, coil temps, fan rpm, …)
+- Works alongside the original wall remote on the same bus
+
+## HM YAML configuration
+
+Use the same `logger:`, `external_components:` and `uart:` blocks as the main install section above; the only HM-specific change is `frame_format: hm` on the `climate:` component:
+
+```yaml
+climate:
+  - platform: toshiba_ab
+    name: "Toshiba AC"
+    id: toshiba_ac
+    frame_format: hm
+    master: 0x00
+    master_address_auto: false     # recommended for HM (stops a corrupt frame hijacking auto-detect)
+    connected:
+      name: "Toshiba AC Connected"
+```
+
+See `complete_example.yaml` for the optional diagnostic sensors and other options.
+
+## Caveats
+
+- **CRC is tolerated, not validated** — the HM CRC algorithm has not been derived yet, so frames are accepted on structure rather than checksum. In practice this is reliable, but it is less strict than the classic / Estia paths.
+- **Fan speeds**: the indoor unit exposes three real speeds (Low / Medium / High) plus Auto on the bus; a wall remote that shows more "bars" maps several of them onto these three.
+- HM support is newer than the classic TCC-Link path — please report issues.
+
+## Tested with
+
+- Indoor: **RAV-RM801BTP-E** (HM range)
+- Outdoor: **RAV-GM801ATP-E** (TU2C-Link-capable)
+- makusets v3.2 board (ESP-12F)
+
+
 # More options and complete yaml
 
 Have a look at the complete_example.yaml file for more options available for the component. It includes details about reporting a chosen temperature to the AC central unit or reading extra sensors (power, pressure, runtime, temp...)

--- a/components/toshiba_ab/climate.py
+++ b/components/toshiba_ab/climate.py
@@ -120,6 +120,34 @@ REPORT_SENSOR_TEMP_SCHEMA = cv.Schema({
 })
 
 
+CONF_HARDWARE_UART_RX_PIN = "hardware_uart_rx_pin"
+
+
+def _hardware_uart_rx_pin(value):
+    """Accept GPIO3 or GPIO13 — the only ESP8266 UART0 hardware RX pins.
+
+    Lets an ESP8266 install whose RX is on a hardware-UART pin (but whose TX is
+    not, so ESPHome would otherwise bit-bang both) move RX onto the real hardware
+    UART. This removes the software-serial RX busy-wait that starves Wi-Fi and
+    trips the watchdog on busy buses. TX stays on the configured uart tx_pin.
+    """
+    original = value
+    if isinstance(value, str) and value.strip().upper().startswith("GPIO"):
+        value = value.strip()[4:]
+    try:
+        num = int(value)
+    except (TypeError, ValueError):
+        raise cv.Invalid(
+            f"{CONF_HARDWARE_UART_RX_PIN} must be GPIO3 or GPIO13, got {original!r}"
+        )
+    if num not in (3, 13):
+        raise cv.Invalid(
+            f"{CONF_HARDWARE_UART_RX_PIN} must be GPIO3 or GPIO13 "
+            "(the only ESP8266 hardware UART0 RX pins)"
+        )
+    return num
+
+
 CONFIG_SCHEMA = climate._CLIMATE_SCHEMA.extend(
     {
         cv.Optional(CONF_MASTER, default=0x00): cv.uint8_t,
@@ -129,6 +157,9 @@ CONFIG_SCHEMA = climate._CLIMATE_SCHEMA.extend(
         cv.Optional(CONF_COMMAND_MODE_WRITE, default=0x80): cv.uint8_t,
         cv.Optional(CONF_FRAME_FORMAT, default="n"): cv.one_of(*FRAME_FORMATS, lower=True),
         cv.Optional(CONF_FILTER_FRAMES, default=True): cv.boolean,
+        # Opt-in (ESP8266): receive on hardware UART0 (GPIO3 or GPIO13) instead of
+        # software serial, to avoid the RX busy-wait that trips the watchdog.
+        cv.Optional(CONF_HARDWARE_UART_RX_PIN): _hardware_uart_rx_pin,
 
         cv.GenerateID(): cv.declare_id(ToshibaAbClimate),
         cv.Optional(CONF_CONNECTED): binary_sensor.binary_sensor_schema(
@@ -207,8 +238,12 @@ CONFIG_SCHEMA = climate._CLIMATE_SCHEMA.extend(
 ).extend(uart.UART_DEVICE_SCHEMA).extend(cv.COMPONENT_SCHEMA)
 
 def validate_uart(config):
+    # When hardware_uart_rx_pin is set, the component owns RX via the hardware
+    # UART0, so the `uart:` block must be TX-only — don't require an rx_pin.
+    # Otherwise keep the original requirement that the uart provides RX.
+    require_rx = CONF_HARDWARE_UART_RX_PIN not in config
     uart.final_validate_device_schema(
-        "tcc_link", baud_rate=2400, require_rx=True, require_tx=False
+        "tcc_link", baud_rate=2400, require_rx=require_rx, require_tx=False
     )(config)
 
 
@@ -236,6 +271,8 @@ async def to_code(config):
         cg.add(var.set_frame_format(FRAME_FORMATS[config[CONF_FRAME_FORMAT]]))
     if CONF_FILTER_FRAMES in config:
         cg.add(var.set_filter_frames(config[CONF_FILTER_FRAMES]))
+    if CONF_HARDWARE_UART_RX_PIN in config:
+        cg.add(var.set_hardware_uart_rx_pin(config[CONF_HARDWARE_UART_RX_PIN]))
 
     if CONF_CONNECTED in config:
         sens = await binary_sensor.new_binary_sensor(config[CONF_CONNECTED])

--- a/components/toshiba_ab/toshiba_ab.cpp
+++ b/components/toshiba_ab/toshiba_ab.cpp
@@ -42,6 +42,12 @@ const LogString *opcode_to_string(uint8_t opcode) {
 
 uint8_t temp_celcius_to_payload(float t) {
   // raw = round( (t + offset) * ratio )
+  // Guard NaN: lround(NaN) is impl-defined and cast-to-uint8 was producing
+  // 0xFF, which the AC decodes as 92.5°C and the wall remote displays as 92.
+  // Substitute 22°C as a safe fallback before any encoding.
+  if (std::isnan(t)) {
+    t = 22.0f;
+  }
   const float scaled = (t + TEMPERATURE_CONVERSION_OFFSET) * TEMPERATURE_CONVERSION_RATIO;
   int v = static_cast<int>(std::lround(scaled));
   if (v < 0) v = 0;
@@ -1011,6 +1017,19 @@ void ToshibaAbClimate::setup() {
   }
   ESP_LOGD("toshiba", "Setting up ToshibaClimate...");
 
+  // Restore last-known mode/target_temp/fan_mode from preferences so we never
+  // boot with target_temperature = NaN. Without this, a control command sent
+  // before the first valid STATUS frame encodes NaN -> 0xFF -> 92.5°C and the
+  // wall remote shows 92. `restore_from_flash: true` in YAML makes this also
+  // survive a power loss; otherwise it survives OTA + WDT reboots via RTC.
+  auto restore = this->restore_state_();
+  if (restore.has_value()) {
+    restore->apply(this);
+  } else {
+    this->target_temperature = 22.0f;
+    this->mode = climate::CLIMATE_MODE_OFF;
+  }
+
   // Override traits for Estia heat pump
   if (this->data_reader.frame_format() == FrameFormat::A0) {
     this->traits_.set_supported_modes({
@@ -1251,8 +1270,14 @@ void ToshibaAbClimate::process_received_data(const struct DataFrame *frame) {
         case OPCODE_STATUS: {
           // sync power, mode, fan and target temp from the unit to the climate
           // component
-          if (frame->size() <= 5 || frame->raw[5] != 0x81) {
-            log_data_frame("STATUS ignored (raw[5] != 0x81)", frame);
+          // Sanity-guard: the AC's 0x81 marker byte lives at a format-dependent
+          // offset. Classic TCC-Link puts it at raw[5] (data[1]); HM puts it at
+          // raw[4] (data[0]). Reject any STATUS frame missing the marker, but
+          // check the right offset per variant — otherwise every HM STATUS
+          // gets dropped and the climate component never syncs from the AC.
+          const uint8_t marker_off = (this->data_reader.frame_format() == FrameFormat::HM) ? 4 : 5;
+          if (frame->size() <= marker_off || frame->raw[marker_off] != 0x81) {
+            log_data_frame("STATUS ignored (marker != 0x81)", frame);
             break;
           }
 
@@ -1280,8 +1305,11 @@ void ToshibaAbClimate::process_received_data(const struct DataFrame *frame) {
         case OPCODE_EXTENDED_STATUS: {
           // sync power, mode, fan and target temp from the unit to the climate
           // component
-          if (frame->size() <= 5 || frame->raw[5] != 0x81) {
-            log_data_frame("EXTENDED STATUS ignored (raw[5] != 0x81)", frame);
+          // See OPCODE_STATUS above for the rationale: 0x81 marker is at
+          // raw[4] on HM, raw[5] on classic.
+          const uint8_t marker_off_ext = (this->data_reader.frame_format() == FrameFormat::HM) ? 4 : 5;
+          if (frame->size() <= marker_off_ext || frame->raw[marker_off_ext] != 0x81) {
+            log_data_frame("EXTENDED STATUS ignored (marker != 0x81)", frame);
             break;
           }
 
@@ -2221,7 +2249,17 @@ void ToshibaAbClimate::loop() {
 
   uint8_t bytes_read = 0;
 
-  while (available()) {
+  // Cap bytes drained per loop() tick. HM-variant master broadcasts can be
+  // 60-80 bytes (≈370 ms of wire time at 2400 baud) — well past the
+  // 30 ms-per-component budget. Unbounded draining keeps loop() inside the
+  // soft-serial RX path long enough to starve lwIP/Wi-Fi and trip the WDT
+  // (observed PCs all land at 0x401037xx, soft-serial ISR). 32 bytes ≈
+  // 150 ms of wire time — bounded worst case; unread bytes wait in the
+  // 2048-byte UART buffer for the next tick.
+  constexpr uint8_t MAX_BYTES_PER_LOOP = 32;
+  uint8_t loop_budget = MAX_BYTES_PER_LOOP;
+
+  while (available() && loop_budget-- > 0) {
     int byte = read();
     if (byte >= 0) {
       bytes_read++;
@@ -2256,6 +2294,8 @@ void ToshibaAbClimate::loop() {
       ESP_LOGW(TAG, "Unable to read data");
     }
   }
+
+  App.feed_wdt();
 
   if (bytes_read > 0) {
     loops_with_reads_++;

--- a/components/toshiba_ab/toshiba_ab.cpp
+++ b/components/toshiba_ab/toshiba_ab.cpp
@@ -4,6 +4,9 @@
 #include <inttypes.h>
 #include <cstring>
 #include <cstdlib>
+#ifdef USE_ESP8266
+#include <HardwareSerial.h>
+#endif
 
 
 namespace esphome {
@@ -12,6 +15,13 @@ namespace toshiba_ab {
 
 
 static const char *const TAG = "tcc_link.climate";
+
+#ifdef USE_ESP8266
+// Optional hardware UART0 instance, used for RX only when hardware_uart_rx_pin is
+// configured (see ToshibaAbClimate::set_hardware_uart_rx_pin). ESPHome disables
+// the Arduino global `Serial`, so we own this instance. Only begun when enabled.
+static HardwareSerial s_bus_serial(UART0);
+#endif
 
 
 const LogString *opcode_to_string(uint8_t opcode) {
@@ -647,6 +657,7 @@ bool ToshibaAbClimate::is_tu2c_registration_query_(const DataFrame &frame) const
 }
 
 void ToshibaAbClimate::add_polled_sensor(uint8_t id, float scale, uint32_t interval_ms, sensor::Sensor *sensor) {
+  const size_t sensor_index = this->polled_sensors_.size();
   PolledSensor ps{ id, scale, interval_ms, sensor };
   this->polled_sensors_.push_back(ps);
 
@@ -655,26 +666,38 @@ void ToshibaAbClimate::add_polled_sensor(uint8_t id, float scale, uint32_t inter
   // the actual 0x17 frame is dispatched serially from drain_sensor_query_queue_()
   // so that short-form 0x1A replies (which carry no sensor ID) can be
   // attributed unambiguously to the most recently sent query.
+  //
+  // Do not start all pollers immediately after boot: ESP8266 Wi-Fi/API
+  // reconnect plus software-serial RX is watchdog-sensitive. Start polling
+  // after a grace period and stagger each sensor so the first burst cannot
+  // swamp the bus or the API connection.
   if (interval_ms > 0) {
-    this->set_interval(interval_ms, [this, id]() {
-      if (this->pending_count_ >= MAX_PENDING_SENSOR_QUERIES) {
-        ESP_LOGW(TAG, "Sensor query queue full; dropping query for 0x%02X", id);
-        return;
-      }
-      // Skip if this sensor is already pending — the next interval will retry.
-      constexpr uint8_t mask = MAX_PENDING_SENSOR_QUERIES - 1;
-      for (uint8_t i = 0; i < this->pending_count_; i++) {
-        if (this->pending_sensor_queries_[(this->pending_head_ + i) & mask] == id) return;
-      }
-      const uint8_t tail = (this->pending_head_ + this->pending_count_) & mask;
-      this->pending_sensor_queries_[tail] = id;
-      this->pending_count_++;
+    const uint32_t first_poll_delay_ms = 15000 + static_cast<uint32_t>(sensor_index) * 2000;
+    this->set_timeout(first_poll_delay_ms, [this, id, interval_ms]() {
+      this->enqueue_sensor_query_(id);
+      this->set_interval(interval_ms, [this, id]() { this->enqueue_sensor_query_(id); });
     });
   }
   
     // Ensure the read-only switch reports its initial state to Home Assistant
     if (this->read_only_switch_)
       this->read_only_switch_->publish_state(this->read_only_);
+}
+
+bool ToshibaAbClimate::enqueue_sensor_query_(uint8_t id) {
+  if (this->pending_count_ >= MAX_PENDING_SENSOR_QUERIES) {
+    ESP_LOGW(TAG, "Sensor query queue full; dropping query for 0x%02X", id);
+    return false;
+  }
+  // Skip if this sensor is already pending — the next interval will retry.
+  constexpr uint8_t mask = MAX_PENDING_SENSOR_QUERIES - 1;
+  for (uint8_t i = 0; i < this->pending_count_; i++) {
+    if (this->pending_sensor_queries_[(this->pending_head_ + i) & mask] == id) return false;
+  }
+  const uint8_t tail = (this->pending_head_ + this->pending_count_) & mask;
+  this->pending_sensor_queries_[tail] = id;
+  this->pending_count_++;
+  return true;
 }
 
 void ToshibaAbClimate::send_sensor_query(uint8_t sensor_id) {
@@ -707,7 +730,7 @@ void ToshibaAbClimate::send_sensor_query(uint8_t sensor_id) {
 
 void ToshibaAbClimate::drain_sensor_query_queue_() {
   // sensor_query_outstanding_ is cleared by process_sensor_value_() on a
-  // matching reply, or by the 1s timeout watchdog if a reply never
+  // matching reply, or by the sensor-query timeout watchdog if a reply never
   // arrives — so a stuck query never deadlocks the queue.
   if (this->sensor_query_outstanding_) return;
   if (this->pending_count_ == 0) return;
@@ -1048,6 +1071,25 @@ void ToshibaAbClimate::setup() {
 
   pinMode(16, OUTPUT); // Set GPIO16 low, only needed for my old board, to be removed soon
   digitalWrite(16, LOW);
+
+  // --- Optional hardware-UART RX (see set_hardware_uart_rx_pin) ---
+  // When the bus RX pin is an ESP8266 hardware-UART0 pin (GPIO3, or GPIO13 via
+  // swap) but TX is not, ESPHome would bit-bang both. The software-serial RX ISR
+  // busy-waits ~1 char time per byte at 2400 baud, starving Wi-Fi enough to trip
+  // the watchdog on busy buses (makusets#88). Moving RX onto the real hardware
+  // UART gives a FIFO-backed, zero-busy-wait receiver. TX stays on the ESPHome
+  // software-serial parent (configured tx_pin). UART0 is free when logger
+  // baud_rate is 0. Disabled by default, so all other configs are unaffected.
+#ifdef USE_ESP8266
+  if (this->hw_uart_rx_enabled_) {
+    s_bus_serial.setRxBufferSize(512);
+    s_bus_serial.begin(2400, SERIAL_8E1);
+    if (this->hw_uart_rx_pin_ == 13) {
+      s_bus_serial.swap();  // UART0: RX GPIO3->GPIO13, TX GPIO1->GPIO15 (unused)
+    }
+    ESP_LOGCONFIG(TAG, "Hardware UART0 RX enabled on GPIO%u", this->hw_uart_rx_pin_);
+  }
+#endif
 
   // If autonomous mode is enabled, we need to send ping, E8 read, and external temp periodically
   // Send all these if autonomous mode is enabled using set_interval calls
@@ -2259,8 +2301,22 @@ void ToshibaAbClimate::loop() {
   constexpr uint8_t MAX_BYTES_PER_LOOP = 32;
   uint8_t loop_budget = MAX_BYTES_PER_LOOP;
 
-  while (available() && loop_budget-- > 0) {
-    int byte = read();
+  // Read from hardware UART0 RX when enabled (no busy-wait), else from the
+  // ESPHome software-serial parent (existing behavior).
+  while (loop_budget > 0) {
+#ifdef USE_ESP8266
+    const bool have = this->hw_uart_rx_enabled_ ? (s_bus_serial.available() > 0) : (this->available() > 0);
+#else
+    const bool have = this->available() > 0;
+#endif
+    if (!have)
+      break;
+    loop_budget--;
+#ifdef USE_ESP8266
+    int byte = this->hw_uart_rx_enabled_ ? s_bus_serial.read() : this->read();
+#else
+    int byte = this->read();
+#endif
     if (byte >= 0) {
       bytes_read++;
 

--- a/components/toshiba_ab/toshiba_ab.h
+++ b/components/toshiba_ab/toshiba_ab.h
@@ -674,6 +674,16 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
   void set_frame_format(FrameFormat format) { data_reader.set_frame_format(format); }
   bool is_hm_variant() const { return data_reader.frame_format() == FrameFormat::HM; }
 
+  // Opt-in (ESP8266 only): receive on the hardware UART0 using `pin` (GPIO3 or
+  // GPIO13) instead of ESPHome's software serial. The software-serial RX ISR
+  // busy-waits ~1 char time per byte and starves Wi-Fi enough to trip the
+  // watchdog on busy buses; the hardware UART has a FIFO and no busy-wait. TX
+  // stays on the configured uart tx_pin (software serial). No effect elsewhere.
+  void set_hardware_uart_rx_pin(uint8_t pin) {
+    this->hw_uart_rx_pin_ = pin;
+    this->hw_uart_rx_enabled_ = true;
+  }
+
   climate::ClimateTraits traits() override;
   void control(const climate::ClimateCall &call) override;
 
@@ -740,6 +750,11 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
  protected:
   climate::ClimateTraits traits_;
 
+  // Hardware-UART-RX opt-in (see set_hardware_uart_rx_pin). Disabled by default
+  // so existing configs are byte-for-byte unchanged.
+  bool hw_uart_rx_enabled_{false};
+  uint8_t hw_uart_rx_pin_{0};
+
   DataFrameReader data_reader;
   TccState tcc_state;
 
@@ -791,7 +806,7 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
   uint8_t last_sensor_query_id_{0xFF};     // 0xFF = invalid / none
   bool    sensor_query_outstanding_{false}; // true after send, cleared on reply
   uint32_t last_sensor_query_ms_{0};
-  uint32_t sensor_query_timeout_ms_{1000};  // 3s default; adjust if needed
+  uint32_t sensor_query_timeout_ms_{2500};  // Give busy HM buses time to answer before releasing the guard.
   uint32_t sensor_query_timeouts_{0};       // (optional) stats
 
   // Pending-query ring buffer. Periodic intervals push sensor IDs here;
@@ -812,6 +827,7 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
   // gating; sensor queries are throttled when the write queue is this
   // deep so we don't pile commands behind a slow bus.
   static constexpr size_t WRITE_QUEUE_THROTTLE = 3;
+  bool enqueue_sensor_query_(uint8_t id);
   void drain_sensor_query_queue_();
 
   // room temperature sensor reporting to AC  ******************************


### PR DESCRIPTION
A few small fixes against a live RAV-RM801BTP-E install. Classic / TU2C paths are unchanged — the variant-specific bits are gated on `frame_format() == FrameFormat::HM`.

- **NaN guard in `temp_celcius_to_payload`** — before the first STATUS sync, `target_temperature` is NaN; `lround(NaN * ratio + offset)` was undefined-behaving to `0xFF` → AC decoded `92.5 °C`. Substitute `22 °C` before encoding.
- **`restore_state_()` on setup** — persist mode/target/fan across boots so we don't re-enter the NaN window on every reboot.
- **STATUS / EXTENDED_STATUS marker offset** — `0x81` lives at `raw[5]` on classic and `raw[4]` on HM. The existing `raw[5] != 0x81` guard was rejecting every HM frame, so `tcc_state` never synced. Pick the offset per variant.
- **Per-loop byte budget on the RX drain (+`feed_wdt`)** — HM master broadcasts are 60–80 bytes; the unbounded `while (available())` kept `loop()` inside the soft-serial path long enough to trip the WDT. Cap at 32 bytes/tick.