### PR TITLE
Auto-detect ESP8266 UART0 RX (GPIO13) and use hardware UART0; update schema and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,12 @@ uart:
   parity: EVEN
   rx_buffer_size: 2048    # increase buffer to avoid dropped bytes
 
+# ESP8266 note: when rx_pin is GPIO13 and tx_pin is not GPIO15, the Toshiba
+# component automatically moves RX onto hardware UART0 swap to avoid ESPHome
+# software-serial RX busy-wait watchdog issues. For any other rx_pin, the
+# normal ESPHome UART RX path is used unless hardware_uart_rx_pin is set
+# explicitly to GPIO3 or GPIO13 under the climate component.
+
 climate:
   - platform: toshiba_ab
     name: "Toshiba AC"

--- a/components/toshiba_ab/climate.py
+++ b/components/toshiba_ab/climate.py
@@ -1,18 +1,22 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import automation
+import esphome.final_validate as fv
 from esphome.components import climate, uart, binary_sensor, sensor, switch, text_sensor, template
 from esphome.const import (
     CONF_ID,
     CONF_NAME,
     CONF_SENSOR,
-    CONF_HARDWARE_UART,
     CONF_BAUD_RATE,
+    CONF_NUMBER,
+    CONF_RX_PIN,
+    CONF_TX_PIN,
     CONF_UPDATE_INTERVAL,
     CONF_MODE,
     CONF_FAN_MODE,
     CONF_SWING_MODE,
     CONF_TRIGGER_ID,
+    CONF_UART_ID,
     DEVICE_CLASS_CONNECTIVITY,
     DEVICE_CLASS_DURATION,
     DEVICE_CLASS_TEMPERATURE,
@@ -22,6 +26,7 @@ from esphome.const import (
     UNIT_CELSIUS,
     UNIT_HOUR,
 )
+from esphome.core import CORE
 
 DEPENDENCIES = ["uart"]
 AUTO_LOAD = ["climate", "binary_sensor", "sensor", "switch"]
@@ -157,8 +162,8 @@ CONFIG_SCHEMA = climate._CLIMATE_SCHEMA.extend(
         cv.Optional(CONF_COMMAND_MODE_WRITE, default=0x80): cv.uint8_t,
         cv.Optional(CONF_FRAME_FORMAT, default="n"): cv.one_of(*FRAME_FORMATS, lower=True),
         cv.Optional(CONF_FILTER_FRAMES, default=True): cv.boolean,
-        # Opt-in (ESP8266): receive on hardware UART0 (GPIO3 or GPIO13) instead of
-        # software serial, to avoid the RX busy-wait that trips the watchdog.
+        # Manual override for hardware UART0 RX. The common ESP8266 case
+        # (uart.rx_pin GPIO13 with a non-UART0 TX pin) is auto-detected below.
         cv.Optional(CONF_HARDWARE_UART_RX_PIN): _hardware_uart_rx_pin,
 
         cv.GenerateID(): cv.declare_id(ToshibaAbClimate),
@@ -237,17 +242,57 @@ CONFIG_SCHEMA = climate._CLIMATE_SCHEMA.extend(
     }
 ).extend(uart.UART_DEVICE_SCHEMA).extend(cv.COMPONENT_SCHEMA)
 
+
+def _pin_number(config):
+    if not isinstance(config, dict):
+        return None
+    return config.get(CONF_NUMBER)
+
+
+def _auto_hardware_uart_rx_pin(config):
+    # On ESP8266, a bus wired as TX=software pin + RX=GPIO13 makes ESPHome use
+    # software serial for both directions. Remove RX from the ESPHome UART hub so
+    # it stays TX-only, then let this component read GPIO13 through UART0 swap.
+    # For every other RX pin, leave the hub untouched and keep the normal ESPHome
+    # UART receive path unless hardware_uart_rx_pin is set explicitly. If TX is
+    # GPIO15, ESPHome can already use swapped UART0 by itself.
+    if not CORE.is_esp8266 or CONF_HARDWARE_UART_RX_PIN in config:
+        return None
+
+    auto_pin = None
+
+    def detect_hub(hub_config):
+        nonlocal auto_pin
+        rx_num = _pin_number(hub_config.get(CONF_RX_PIN))
+        tx_num = _pin_number(hub_config.get(CONF_TX_PIN))
+        if rx_num == 13 and tx_num != 15:
+            auto_pin = rx_num
+            hub_config.pop(CONF_RX_PIN, None)
+        return hub_config
+
+    cv.Schema(
+        {cv.Required(CONF_UART_ID): fv.id_declaration_match_schema(detect_hub)},
+        extra=cv.ALLOW_EXTRA,
+    )(config)
+    return auto_pin
+
+
 def validate_uart(config):
-    # When hardware_uart_rx_pin is set, the component owns RX via the hardware
-    # UART0, so the `uart:` block must be TX-only — don't require an rx_pin.
-    # Otherwise keep the original requirement that the uart provides RX.
-    require_rx = CONF_HARDWARE_UART_RX_PIN not in config
+    # When hardware_uart_rx_pin is set explicitly, or when we can auto-detect the
+    # ESP8266 GPIO13 RX/software-TX case, the component owns RX via UART0 and the
+    # ESPHome `uart:` hub must be TX-only. Otherwise keep requiring uart.rx_pin.
+    auto_rx_pin = _auto_hardware_uart_rx_pin(config)
+    require_rx = CONF_HARDWARE_UART_RX_PIN not in config and auto_rx_pin is None
     uart.final_validate_device_schema(
         "tcc_link", baud_rate=2400, require_rx=require_rx, require_tx=False
     )(config)
+    if auto_rx_pin is not None:
+        config[CONF_HARDWARE_UART_RX_PIN] = auto_rx_pin
+    return config
 
 
 FINAL_VALIDATE_SCHEMA = validate_uart
+
 
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])

--- a/components/toshiba_ab/toshiba_ab.cpp
+++ b/components/toshiba_ab/toshiba_ab.cpp
@@ -17,9 +17,10 @@ namespace toshiba_ab {
 static const char *const TAG = "tcc_link.climate";
 
 #ifdef USE_ESP8266
-// Optional hardware UART0 instance, used for RX only when hardware_uart_rx_pin is
-// configured (see ToshibaAbClimate::set_hardware_uart_rx_pin). ESPHome disables
-// the Arduino global `Serial`, so we own this instance. Only begun when enabled.
+// Optional hardware UART0 instance, used for RX only when GPIO13 RX is
+// auto-detected on ESP8266 (or hardware_uart_rx_pin is configured). ESPHome
+// disables the Arduino global `Serial`, so we own this instance. Only begun when
+// enabled.
 static HardwareSerial s_bus_serial(UART0);
 #endif
 
@@ -1072,9 +1073,10 @@ void ToshibaAbClimate::setup() {
   pinMode(16, OUTPUT); // Set GPIO16 low, only needed for my old board, to be removed soon
   digitalWrite(16, LOW);
 
-  // --- Optional hardware-UART RX (see set_hardware_uart_rx_pin) ---
-  // When the bus RX pin is an ESP8266 hardware-UART0 pin (GPIO3, or GPIO13 via
-  // swap) but TX is not, ESPHome would bit-bang both. The software-serial RX ISR
+  // --- Optional/auto hardware-UART RX (see set_hardware_uart_rx_pin) ---
+  // When the bus RX pin is an ESP8266 hardware-UART0 pin (GPIO13 via swap, or
+  // GPIO3 via explicit config) but TX is not, ESPHome would bit-bang both. The
+  // software-serial RX ISR
   // busy-waits ~1 char time per byte at 2400 baud, starving Wi-Fi enough to trip
   // the watchdog on busy buses (makusets#88). Moving RX onto the real hardware
   // UART gives a FIFO-backed, zero-busy-wait receiver. TX stays on the ESPHome

--- a/components/toshiba_ab/toshiba_ab.h
+++ b/components/toshiba_ab/toshiba_ab.h
@@ -674,8 +674,9 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
   void set_frame_format(FrameFormat format) { data_reader.set_frame_format(format); }
   bool is_hm_variant() const { return data_reader.frame_format() == FrameFormat::HM; }
 
-  // Opt-in (ESP8266 only): receive on the hardware UART0 using `pin` (GPIO3 or
-  // GPIO13) instead of ESPHome's software serial. The software-serial RX ISR
+  // ESP8266 only: receive on the hardware UART0 using `pin` (auto-detected for
+  // GPIO13, or explicitly configured for GPIO3/GPIO13) instead of ESPHome's
+  // software serial. The software-serial RX ISR
   // busy-waits ~1 char time per byte and starves Wi-Fi enough to trip the
   // watchdog on busy buses; the hardware UART has a FIFO and no busy-wait. TX
   // stays on the configured uart tx_pin (software serial). No effect elsewhere.
@@ -750,8 +751,8 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
  protected:
   climate::ClimateTraits traits_;
 
-  // Hardware-UART-RX opt-in (see set_hardware_uart_rx_pin). Disabled by default
-  // so existing configs are byte-for-byte unchanged.
+  // Hardware-UART-RX mode (see set_hardware_uart_rx_pin). Disabled by default
+  // unless final validation detects the ESP8266 GPIO13 RX/software-TX case.
   bool hw_uart_rx_enabled_{false};
   uint8_t hw_uart_rx_pin_{0};
 


### PR DESCRIPTION
### Motivation
- Avoid ESP8266 watchdog crashes when the bus RX is connected to GPIO13 while TX is a software pin by moving RX to hardware UART0 automatically instead of requiring manual opt-in.
- Make the component configuration and validation handle the common ESP8266 wiring case (RX=GPIO13, TX!=GPIO15) without user intervention and document the behavior in the README.

### Description
- Added automatic detection logic in `components/toshiba_ab/climate.py` via `_auto_hardware_uart_rx_pin` and `_pin_number` to detect `uart:` hubs with `rx_pin` GPIO13 and non-UART0 `tx_pin`, removing the hub `rx_pin` so the component can own UART0 RX. 
- Updated configuration validation in `validate_uart` to consider the auto-detect case and set `CONF_HARDWARE_UART_RX_PIN` when detected, and to adjust the `require_rx` behavior passed to `uart.final_validate_device_schema` accordingly.
- Imported `esphome.final_validate` and `esphome.core.CORE` to implement final-schema matching and platform checks, and added `CONF_UART_ID`, `CONF_RX_PIN`, and `CONF_TX_PIN` usages for hub detection.
- Updated C++ (`toshiba_ab.cpp` and header) comments and behavior notes to clarify the auto/optional hardware-UART RX handling on ESP8266; hardware UART instance remains controlled and only begun when enabled.
- Added a README note explaining the ESP8266 GPIO13 auto-swap behavior and when ESPHome will use hardware UART0 for RX.

### Testing
- Ran ESPHome configuration/schema validation for an ESP8266 device with a `uart:` hub wired as `rx_pin: GPIO13` and `tx_pin` not GPIO15 and confirmed the component final validation sets `hardware_uart_rx_pin` and accepts a TX-only `uart:` hub (validation succeeded).
- Built a firmware image for an ESP8266 target including the modified component to ensure compilation succeeded (build succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c0949b92c832fbdbbc579a17b0bc2)