### PR TITLE
Add automatic frame format detection

### DIFF
--- a/components/toshiba_ab/climate.py
+++ b/components/toshiba_ab/climate.py
@@ -97,6 +97,7 @@ ToshibaAbSendRawFrameAction = toshiba_ab_ns.class_(
 
 FrameFormat = toshiba_ab_ns.enum("FrameFormat")
 FRAME_FORMATS = {
+    "auto": None,
     "n": FrameFormat.NORMAL,
     "normal": FrameFormat.NORMAL,
     "u": FrameFormat.TU2C,
@@ -160,7 +161,7 @@ CONFIG_SCHEMA = climate._CLIMATE_SCHEMA.extend(
         cv.Optional(CONF_MASTER_ADDRESS_AUTO, default=True): cv.boolean,
         cv.Optional(CONF_COMMAND_MODE_READ, default=0x08): cv.uint8_t,
         cv.Optional(CONF_COMMAND_MODE_WRITE, default=0x80): cv.uint8_t,
-        cv.Optional(CONF_FRAME_FORMAT, default="n"): cv.one_of(*FRAME_FORMATS, lower=True),
+        cv.Optional(CONF_FRAME_FORMAT, default="auto"): cv.one_of(*FRAME_FORMATS, lower=True),
         cv.Optional(CONF_FILTER_FRAMES, default=True): cv.boolean,
         # Manual override for hardware UART0 RX. The common ESP8266 case
         # (uart.rx_pin GPIO13 with a non-UART0 TX pin) is auto-detected below.
@@ -313,7 +314,10 @@ async def to_code(config):
     if CONF_COMMAND_MODE_WRITE in config:
         cg.add(var.set_command_mode_write(config[CONF_COMMAND_MODE_WRITE]))
     if CONF_FRAME_FORMAT in config:
-        cg.add(var.set_frame_format(FRAME_FORMATS[config[CONF_FRAME_FORMAT]]))
+        if config[CONF_FRAME_FORMAT] == "auto":
+            cg.add(var.set_frame_format_auto())
+        else:
+            cg.add(var.set_frame_format(FRAME_FORMATS[config[CONF_FRAME_FORMAT]]))
     if CONF_FILTER_FRAMES in config:
         cg.add(var.set_filter_frames(config[CONF_FILTER_FRAMES]))
     if CONF_HARDWARE_UART_RX_PIN in config:

--- a/components/toshiba_ab/toshiba_ab.cpp
+++ b/components/toshiba_ab/toshiba_ab.cpp
@@ -180,6 +180,119 @@ void ToshibaAbClimate::update_frame_validation_() {
   this->data_reader.set_allow_same_source_dest(allow_same);
 }
 
+void ToshibaAbClimate::confirm_frame_format_(FrameFormat format, const char *reason) {
+  if (!this->should_auto_detect_frame_format_()) {
+    return;
+  }
+  this->data_reader.set_frame_format(format);
+  this->frame_format_confirmed_ = true;
+  const char *fmt = "normal";
+  switch (format) {
+    case FrameFormat::TU2C: fmt = "tu2c"; break;
+    case FrameFormat::A0: fmt = "a0"; break;
+    case FrameFormat::HM: fmt = "hm"; break;
+    default: fmt = "n"; break;
+  }
+  ESP_LOGI(TAG, "Auto-detected frame_format=%s (%s)", fmt, reason != nullptr ? reason : "confirmed frame");
+}
+
+void ToshibaAbClimate::watch_auto_frame_format_byte_(uint8_t byte) {
+  if (!this->should_auto_detect_frame_format_()) {
+    return;
+  }
+
+  constexpr uint32_t AUTO_A0_BYTE_TIMEOUT_MS = 50;
+  if (this->auto_a0_collecting_ && (millis() - this->auto_a0_last_byte_ms_) > AUTO_A0_BYTE_TIMEOUT_MS) {
+    this->auto_a0_collecting_ = false;
+    this->auto_a0_prefix_match_ = 0;
+    this->auto_a0_index_ = 0;
+    this->auto_a0_expected_total_ = 0;
+  }
+
+  if (!this->auto_a0_collecting_) {
+    if (this->auto_a0_prefix_match_ == 1) {
+      if (byte == 0x00) {
+        this->auto_a0_collecting_ = true;
+        this->auto_a0_buffer_[0] = 0xA0;
+        this->auto_a0_buffer_[1] = 0x00;
+        this->auto_a0_index_ = 2;
+        this->auto_a0_expected_total_ = 0;
+        this->auto_a0_last_byte_ms_ = millis();
+      }
+      this->auto_a0_prefix_match_ = 0;
+      return;
+    }
+    if (byte == 0xA0) {
+      this->auto_a0_prefix_match_ = 1;
+    }
+    return;
+  }
+
+  this->auto_a0_last_byte_ms_ = millis();
+  if (this->auto_a0_index_ >= sizeof(this->auto_a0_buffer_)) {
+    this->auto_a0_collecting_ = false;
+    this->auto_a0_index_ = 0;
+    this->auto_a0_expected_total_ = 0;
+    return;
+  }
+
+  this->auto_a0_buffer_[this->auto_a0_index_++] = byte;
+  if (this->auto_a0_index_ == 4) {
+    const uint8_t len = this->auto_a0_buffer_[3];
+    this->auto_a0_expected_total_ = len + 6;  // A0:00 prefix + type + len + len-payload + CRC16
+    if (this->auto_a0_expected_total_ < 8 || this->auto_a0_expected_total_ > sizeof(this->auto_a0_buffer_)) {
+      this->auto_a0_collecting_ = false;
+      this->auto_a0_index_ = 0;
+      this->auto_a0_expected_total_ = 0;
+      return;
+    }
+  }
+
+  if (this->auto_a0_expected_total_ > 0 && this->auto_a0_index_ >= this->auto_a0_expected_total_) {
+    DataFrame candidate{};
+    const uint16_t stored = this->auto_a0_expected_total_ - 2;
+    for (uint16_t i = 0; i < stored && i < DATA_FRAME_MAX_SIZE; i++) {
+      candidate.raw[i] = this->auto_a0_buffer_[i + 2];
+    }
+    candidate.set_estia(true);
+    candidate.set_estia_len(this->auto_a0_buffer_[3]);
+    const uint16_t src = (stored > 4) ? ((candidate.raw[3] << 8) | candidate.raw[4]) : 0;
+    if (candidate.validate_estia_crc() && src == 0x0800) {
+      this->confirm_frame_format_(FrameFormat::A0, "valid A0 frame from master");
+    }
+    this->auto_a0_collecting_ = false;
+    this->auto_a0_index_ = 0;
+    this->auto_a0_expected_total_ = 0;
+  }
+}
+
+bool ToshibaAbClimate::is_hm_wire_frame_from_master_(const DataFrame *frame) const {
+  if (frame == nullptr || frame->raw[0] != 0xA0 || frame->raw[1] != 0x00 || frame->data_length < 7) {
+    return false;
+  }
+  const size_t total = frame->size();
+  if (total < 12 || frame->raw[4] != 0x00 || frame->raw[9] != 0x00) {
+    return false;
+  }
+  const uint8_t src = frame->raw[6];
+  if (src == this->master_address_) {
+    return true;
+  }
+  return this->master_address_auto_ && this->master_address_ == 0x00 && src == 0x00;
+}
+
+bool ToshibaAbClimate::maybe_auto_detect_hm_frame_(DataFrame *frame) {
+  if (!this->should_auto_detect_frame_format_() || !this->is_hm_wire_frame_from_master_(frame)) {
+    return false;
+  }
+  const uint8_t detected_master = frame->raw[6];
+  this->confirm_frame_format_(FrameFormat::HM, "valid HM frame from master");
+  if (this->master_address_auto_ && detected_master != this->master_address_) {
+    this->master_address_ = detected_master;
+  }
+  return DataFrameReader::canonicalize_hm_frame(frame, frame->size());
+}
+
 bool ToshibaAbClimate::has_bus_quiet_time_elapsed_(uint32_t now) const {
   return (now - this->last_received_frame_millis_) >= FRAME_SEND_MILLIS_FROM_LAST_RECEIVE &&
          (now - this->last_sent_frame_millis_) >= FRAME_SEND_MILLIS_FROM_LAST_SEND;
@@ -1017,7 +1130,8 @@ void ToshibaAbClimate::dump_config() {
     case FrameFormat::HM: fmt_label = "HM (RAV-RM/HM range)"; break;
     default: fmt_label = "TCC-Link"; break;
   }
-  ESP_LOGCONFIG(TAG, "  Frame format: %s", fmt_label);
+  ESP_LOGCONFIG(TAG, "  Frame format: %s%s%s", fmt_label, this->frame_format_auto_ ? " (auto" : "",
+                this->frame_format_auto_ ? (this->frame_format_confirmed_ ? ", confirmed)" : ", pending)") : "");
 #ifdef USE_ESP8266
   if (this->hw_uart_rx_enabled_) {
     ESP_LOGCONFIG(TAG, "  Hardware UART0 RX: enabled");
@@ -1288,6 +1402,7 @@ void ToshibaAbClimate::process_received_data(const struct DataFrame *frame) {
       switch (frame->opcode1) {
         case OPCODE_PING: {
         log_data_frame("PING/ALIVE", frame);
+        this->confirm_frame_format_(FrameFormat::NORMAL, "valid keepalive from master");
         break;
         }
         case OPCODE_ACK: {
@@ -2085,6 +2200,14 @@ bool ToshibaAbClimate::receive_data_frame(const struct DataFrame *frame) {
 
     return true;
   }
+  DataFrame auto_detected_frame{};
+  if (this->should_auto_detect_frame_format_() && this->is_hm_wire_frame_from_master_(frame)) {
+    auto_detected_frame = *frame;
+    if (this->maybe_auto_detect_hm_frame_(&auto_detected_frame)) {
+      frame = &auto_detected_frame;
+    }
+  }
+
   if (!frame->is_tu2c() && frame->crc() != frame->calculate_crc()) {
     if (this->failed_crcs_sensor_ != nullptr) {
       this->failed_crcs_sensor_->publish_state(this->failed_crcs_sensor_->state + 1);
@@ -2342,6 +2465,8 @@ void ToshibaAbClimate::loop() {
 
       if (!can_read_packet)
         continue;  // wait until can read packet
+
+      this->watch_auto_frame_format_byte_(static_cast<uint8_t>(byte));
 
       if (data_reader.put(byte)) {
         // packet complete

--- a/components/toshiba_ab/toshiba_ab.h
+++ b/components/toshiba_ab/toshiba_ab.h
@@ -531,31 +531,7 @@ struct DataFrameReader {
         if (frame_format_ == FrameFormat::HM
             && frame.raw[0] == 0xA0 && frame.raw[1] == 0x00
             && frame.data_length >= 7) {
-          const uint16_t total = expected_total_;
-          const uint8_t crc_byte = frame.raw[total - 1];
-          const uint8_t new_src = frame.raw[6];
-          const uint8_t new_dst = frame.raw[8];
-          const uint8_t new_data_length = frame.data_length - 5;
-          const uint8_t opcode2 = frame.raw[10];
-          // Real payload after opcode2 in the wire frame is
-          // (data_length - 7) bytes, located at wire raw[11..total-2].
-          const uint8_t tail_len = frame.data_length - 7;
-          // raw[4] = opcode2, raw[5] = 0x00 padding, raw[6..] = tail.
-          // Source range raw[11..] is to the RIGHT of destination range
-          // raw[6..]; iterate forward so each source byte is read before
-          // any subsequent write could overwrite it.
-          for (uint8_t i = 0; i < tail_len; i++) {
-            frame.raw[DATA_OFFSET_FROM_START + 2 + i] = frame.raw[11 + i];
-          }
-          frame.raw[DATA_OFFSET_FROM_START + 0] = opcode2;
-          frame.raw[DATA_OFFSET_FROM_START + 1] = 0x00;
-          frame.raw[0] = new_src;
-          frame.raw[1] = new_dst;
-          // raw[2] (opcode1) is at the same wire offset in HM as in
-          // NORMAL; only the length value changes.
-          frame.raw[3] = new_data_length;
-          frame.data_length = new_data_length;
-          frame.raw[DATA_OFFSET_FROM_START + new_data_length] = crc_byte;
+          DataFrameReader::canonicalize_hm_frame(&frame, expected_total_);
           // CRC algorithm for HM hasn't been derived yet — accept the
           // frame but flag the CRC as unvalidated so callers can decide.
           crc_valid = false;
@@ -579,6 +555,31 @@ struct DataFrameReader {
     }
 
     return false;
+  }
+
+
+  static bool canonicalize_hm_frame(DataFrame *hm_frame, uint16_t total) {
+    if (hm_frame == nullptr || total < 12 || hm_frame->raw[0] != 0xA0 || hm_frame->raw[1] != 0x00 ||
+        hm_frame->data_length < 7) {
+      return false;
+    }
+    const uint8_t crc_byte = hm_frame->raw[total - 1];
+    const uint8_t new_src = hm_frame->raw[6];
+    const uint8_t new_dst = hm_frame->raw[8];
+    const uint8_t new_data_length = hm_frame->data_length - 5;
+    const uint8_t opcode2 = hm_frame->raw[10];
+    const uint8_t tail_len = hm_frame->data_length - 7;
+    for (uint8_t i = 0; i < tail_len; i++) {
+      hm_frame->raw[DATA_OFFSET_FROM_START + 2 + i] = hm_frame->raw[11 + i];
+    }
+    hm_frame->raw[DATA_OFFSET_FROM_START + 0] = opcode2;
+    hm_frame->raw[DATA_OFFSET_FROM_START + 1] = 0x00;
+    hm_frame->raw[0] = new_src;
+    hm_frame->raw[1] = new_dst;
+    hm_frame->raw[3] = new_data_length;
+    hm_frame->data_length = new_data_length;
+    hm_frame->raw[DATA_OFFSET_FROM_START + new_data_length] = crc_byte;
+    return true;
   }
 
   void set_filter_frames(bool filter_frames) { filter_frames_ = filter_frames; }
@@ -671,7 +672,16 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
   void set_waterpump_hours_sensor(sensor::Sensor *sensor) { waterpump_hours_sensor_ = sensor; }
   void set_backup_heater_hours_sensor(sensor::Sensor *sensor) { backup_heater_hours_sensor_ = sensor; }
   void set_demand_sensor(sensor::Sensor *sensor) { demand_sensor_ = sensor; }
-  void set_frame_format(FrameFormat format) { data_reader.set_frame_format(format); }
+  void set_frame_format(FrameFormat format) {
+    data_reader.set_frame_format(format);
+    frame_format_auto_ = false;
+    frame_format_confirmed_ = true;
+  }
+  void set_frame_format_auto() {
+    data_reader.set_frame_format(FrameFormat::NORMAL);
+    frame_format_auto_ = true;
+    frame_format_confirmed_ = false;
+  }
   bool is_hm_variant() const { return data_reader.frame_format() == FrameFormat::HM; }
 
   // ESP8266 only: receive on the hardware UART0 using `pin` (auto-detected for
@@ -773,6 +783,11 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
   void update_frame_validation_();
   bool has_bus_quiet_time_elapsed_(uint32_t now) const;
   bool has_tu2c_quiet_time_elapsed_(uint32_t now) const;
+  bool should_auto_detect_frame_format_() const { return frame_format_auto_ && !frame_format_confirmed_; }
+  void confirm_frame_format_(FrameFormat format, const char *reason);
+  void watch_auto_frame_format_byte_(uint8_t byte);
+  bool maybe_auto_detect_hm_frame_(DataFrame *frame);
+  bool is_hm_wire_frame_from_master_(const DataFrame *frame) const;
 
 
   std::vector<DataFrame> create_commands(const struct TccState *new_state);
@@ -855,6 +870,15 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
   uint32_t last_sent_millis_ = 0;
   uint32_t last_received_millis_ = 0;
   bool can_read_packet = false;
+
+  bool frame_format_auto_{true};
+  bool frame_format_confirmed_{false};
+  uint8_t auto_a0_prefix_match_{0};
+  bool auto_a0_collecting_{false};
+  uint8_t auto_a0_buffer_[DATA_FRAME_MAX_SIZE + 2]{};
+  uint16_t auto_a0_index_{0};
+  uint16_t auto_a0_expected_total_{0};
+  uint32_t auto_a0_last_byte_ms_{0};
 
   uint32_t last_received_frame_millis_ = 0;
   uint32_t last_sent_frame_millis_ = 0;


### PR DESCRIPTION
### Motivation
- Make the component automatically detect the bus frame format when the user sets `frame_format: auto` while keeping explicit YAML selections authoritative.
- Start the reader in the `normal` layout but only mark the detected format as confirmed after seeing a trustworthy indicator from the master (keepalive/ACK/A0 frames), to avoid mis-detection on noisy wires.
- Support detecting Estia `A0` frames and the HM wrapper variant and canonicalise HM frames so they can be processed even though their CRC algorithm is unknown.

### Description
- Added `auto` option to the `FRAME_FORMATS` map and changed the `CONF_FRAME_FORMAT` default to `"auto"`, routing the config path to a new `set_frame_format_auto()` when `auto` is selected in YAML (`components/toshiba_ab/climate.py`).
- Introduced runtime auto-detection state and helpers: `frame_format_auto_`, `frame_format_confirmed_`, A0 collection buffers, and `watch_auto_frame_format_byte_()` to scan the byte stream for `A0:00` frames (`components/toshiba_ab/toshiba_ab.h` / `.cpp`).
- Implemented confirmation and detection functions: `confirm_frame_format_()` (marks detection confirmed and sets the reader), `maybe_auto_detect_hm_frame_()` and `is_hm_wire_frame_from_master_()` (detects HM-wrapped frames from master and canonicalises them), and an A0 candidate collector that validates Estia CRC and confirms the `A0` format when a valid master-sourced A0 is observed (`components/toshiba_ab/toshiba_ab.cpp`, `DataFrameReader::canonicalize_hm_frame()` in `toshiba_ab.h`).
- When in auto-mode the code now: confirms `NORMAL` on a valid master keepalive (PING), detects and confirms `A0` frames from the raw byte stream, and detects/canonicalises HM frames before CRC rejection so HM traffic is not discarded; explicit YAML frame selections disable the auto-watch behavior.
- Updated `dump_config()` to expose the `auto` state and whether a detected format is pending or confirmed.

### Testing
- Ran `python3 -m py_compile components/toshiba_ab/climate.py` with no syntax errors (success).
- Ran `git diff --check` to ensure no trailing whitespace or index issues (success).
- Attempted `platformio run` but it is not available in the environment (`platformio: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c2113e7dc832f9a06d24b551ef65c)