### PR TITLE
Link GitHub user mentions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,21 @@
 # Updated code (May 2026) - Toshiba ESTIA R32 Heat Pumps Support and more
 
-Thanks to @7tobias the code now supports interfacing with Toshiba R32 Estia Heat Pumps, the board has been tested with the R32 ESTIA Series 1.
+Thanks to [@7tobias](https://github.com/7tobias) the code now supports interfacing with Toshiba R32 Estia Heat Pumps, the board has been tested with the R32 ESTIA Series 1.
 The protocol in ESTIA Heat Pumps changed with the introduction of R32 pumps around 2021.
-Older ESTIA models using R410A use a different protocol. Have a look at https://github.com/vakkeli/toshiba_uart_ctrl for R410 models, @vakkeli integration should be compatible with this board (with the correct UART pins setup in yaml)
+Older ESTIA models using R410A use a different protocol. Have a look at https://github.com/vakkeli/toshiba_uart_ctrl for R410 models, [@vakkeli](https://github.com/vakkeli) integration should be compatible with this board (with the correct UART pins setup in yaml)
 Have a look at the bottom of this page for details and to the example_estia.yaml for setup.
 
 - The esp will now detect what protocol is in use on the AB line automatically, if none is specified.
 - Adress assignment has changed to avoid duplicated adresses that would trigger an E09 error.
-- Thanks to @mtthidoteu, a new protocol variant has been implemented which increases compatibility with some newer models, it is auto detected, and is named "hm" in the code.
-- Thanks to @mtthidoteu  again, the esp will now use hardware UART, which should reduce blocking of code execution and triggering reboots by the watchdog.
-  
+- Thanks to [@mtthidoteu](https://github.com/mtthidoteu), a new protocol variant has been implemented which increases compatibility with some newer models, it is auto detected, and is named "hm" in the code.
+- Thanks to [@mtthidoteu](https://github.com/mtthidoteu)  again, the esp will now use hardware UART, which should reduce blocking of code execution and triggering reboots by the watchdog.
+
 
 # D1 mini board variant
 
-In collaboration with @issalig, the initial developer of this project, we have designed a simpler board to be used with a D1 mini.
+In collaboration with [@issalig](https://github.com/issalig), the initial developer of this project, we have designed a simpler board to be used with a D1 mini.
 
-- The board will work with this code or with @issalig code.
+- The board will work with this code or with [@issalig](https://github.com/issalig) code.
 - UART pins are different. RX: D7 / TX: D8
 - Have a look at issalig project: https://github.com/issalig/toshiba_air_cond
 - Files here: https://github.com/makusets/esphome-toshiba-ab/tree/main/hardware/D1%20mini
@@ -53,13 +53,13 @@ Improvements over v1:
 - Works with a wide voltage range in the AB line (v1 only worked within a very narrow voltage window on the AB line), which should expand compatibility to more toshiba models.
 - Much better filtering of noise and virtually no noise introduced on the AB line.
 - Robust comparator design for data processing with DC filtering capacitor.
-- Selectable power source with slide switch: AB line or USB. Only switch power source with the board completely disconnected, otherwise there is high risk of damaging the circuit. USB data will operate even with AB power. 
+- Selectable power source with slide switch: AB line or USB. Only switch power source with the board completely disconnected, otherwise there is high risk of damaging the circuit. USB data will operate even with AB power.
 
 notes:
 
 - The ESP consumes a lot more energy than the conventional wall remotes due to Wi-Fi. Therefore, the board is powered using a buck converter, as opposed to the LDO used in original Toshiba wall remote. This has the potential of introducing noise and interfere with data transmission. Through testing, I found that the specific make and model of the buck had a big impact on data corruption; as well as a good size capacitor on the 3.3v rail (at least 1000uF). This design has been tested with a DEXU branded buck,both K7803-500 and K7803-1000 and works without issues. If you test other components, please let me know what you found out.
-- The DCDC buck provides 3.3V and then is fed into a 3.3V LDO, although this is counterintuitive, the LDO reduces noise further and is needed for USB power anyway, the specific model chosen allows for 3.3V input. 
-- The data reading is done using DC filtering and then a comparator. The size of the DC filter capacitor is important. 
+- The DCDC buck provides 3.3V and then is fed into a 3.3V LDO, although this is counterintuitive, the LDO reduces noise further and is needed for USB power anyway, the specific model chosen allows for 3.3V input.
+- The data reading is done using DC filtering and then a comparator. The size of the DC filter capacitor is important.
 - The writing is done by pulling the A line low (to B) across a 330ohm resistor for a "0" bit, this is the same approach adopted by toshiba original board.
 
 
@@ -78,18 +78,18 @@ The hardware side of this project includes a ESP12 based board design that conne
 In particular, this project has been tested with remote control unit RBC-AMT32E and RBC-AMT54E and central unit RAV-SM1103DT-A and MMD-AP0366BHP1-E but should work with other models using the AB protocol.
 
 
-Requires reader & writer circuit to interface with the AB line, connected to the remote AB ports. 
+Requires reader & writer circuit to interface with the AB line, connected to the remote AB ports.
 The circuit board was designed in easyEDA and all necessary files are included here.
 
-Most of the work is based on previous work, hard bits of decoding and initial board design by @issalig https://github.com/issalig/toshiba_air_cond and an initial esphome component from @muxa: https://github.com/muxa/esphome-tcc-link
+Most of the work is based on previous work, hard bits of decoding and initial board design by [@issalig](https://github.com/issalig) https://github.com/issalig/toshiba_air_cond and an initial esphome component from [@muxa](https://github.com/muxa): https://github.com/muxa/esphome-tcc-link
 
 # Toshiba protocols compatibility
 
 ## TCC-Link
 
-Toshiba systems using the AB line for communication employ at least two major known protocol variations with further variations within each of them. This project was designed and tested for the initial TCC-Link protocol. And two variations of that protocol are supported at the moment. 
+Toshiba systems using the AB line for communication employ at least two major known protocol variations with further variations within each of them. This project was designed and tested for the initial TCC-Link protocol. And two variations of that protocol are supported at the moment.
 
-Newer HM-range indoor units — the `RAV-RM…BTP-E` series (e.g. **RAV-RM801BTP-E**), typically paired with a outdoor such as the `RAV-GM…ATP-E` series (e.g. **RAV-GM801ATP-E**) — speak a dialect of the classic TCC-Link decoder that the current code should autodetect thanks to @mtthidoteu. Otherwise, it can be set with in yaml with `frame_format: hm`. 
+Newer HM-range indoor units — the `RAV-RM…BTP-E` series (e.g. **RAV-RM801BTP-E**), typically paired with a outdoor such as the `RAV-GM…ATP-E` series (e.g. **RAV-GM801ATP-E**) — speak a dialect of the classic TCC-Link decoder that the current code should autodetect thanks to [@mtthidoteu](https://github.com/mtthidoteu). Otherwise, it can be set with in yaml with `frame_format: hm`.
 The HM dialect differs from classic TCC-Link in a few ways: two fixed intial bytes `A0:00`, source/destination addresses at different byte positions, a longer payload, and few other changes.
 
 ## TU2C
@@ -103,8 +103,8 @@ If you want to help test the board with the TU2C protocol, see: https://github.c
 
 ## Estia heat pumps
 
-Thanks to @7tobias this component also supports Toshiba R32 Estia heat pumps that use a variation of the TU2C protocol, different to that of previous R410A ESTIA pumps. See below for yaml configuration instructions.
-Older ESTIA models using R410A use a different protocol. Have a look at https://github.com/vakkeli/toshiba_uart_ctrl for R410 models, @vakkeli integration should be compatible with this board (with the correct UART pins setup in yaml). Happy to integrate that protocol into this repo if someone wants to run the tests.
+Thanks to [@7tobias](https://github.com/7tobias) this component also supports Toshiba R32 Estia heat pumps that use a variation of the TU2C protocol, different to that of previous R410A ESTIA pumps. See below for yaml configuration instructions.
+Older ESTIA models using R410A use a different protocol. Have a look at https://github.com/vakkeli/toshiba_uart_ctrl for R410 models, [@vakkeli](https://github.com/vakkeli) integration should be compatible with this board (with the correct UART pins setup in yaml). Happy to integrate that protocol into this repo if someone wants to run the tests.
 
 
 ## To install, add or modify these sections in your esphome device yaml file
@@ -112,14 +112,14 @@ Older ESTIA models using R410A use a different protocol. Have a look at https://
 ```yaml
 
 logger:
-  baud_rate: 0  #disable hardware UART log to use pins for UART communication with the AC unit 
+  baud_rate: 0  #disable hardware UART log to use pins for UART communication with the AC unit
   level: DEBUG
 
 external_components:
   - source:
       type: git
       url: https://github.com/makusets/esphome-toshiba-ab
-    refresh: 0s  #optional, how often to download fresh files from source, defaults to 1 day, use 0 to force updates 
+    refresh: 0s  #optional, how often to download fresh files from source, defaults to 1 day, use 0 to force updates
 
 uart:
   tx_pin: GPIO12  #GPIO10 if using v3 board or GPIO15 if using v1 board
@@ -138,7 +138,7 @@ climate:
 
 ## Optional section if you install a BME280 sensor
 
-The option of a BME280 sensor is added to give the option of reading the temperature, pressure and humidity from the thermostat. It is done as any other sensor in the ESPHome environment. If configured, it will be exposed to the frontend. If you want to use this or another sensor to control the AC system, have a look at the complete_exmple.yaml file. 
+The option of a BME280 sensor is added to give the option of reading the temperature, pressure and humidity from the thermostat. It is done as any other sensor in the ESPHome environment. If configured, it will be exposed to the frontend. If you want to use this or another sensor to control the AC system, have a look at the complete_exmple.yaml file.
 
 ```yaml
 # If installed, it will report the BME280 temp, humidity and pressure values
@@ -167,7 +167,7 @@ sensor:
       oversampling: 2x
     address: 0x76
     update_interval: 30s
-    
+
 ```
 
 # Hardware installation
@@ -179,7 +179,7 @@ You will need to build the esphome compatible hardware. Instructions below.
   - **While connected to USB, the board needs to have the Power Selector set to USB**
 - Isolate the AC unit completely off (at the electrical distribution board ideally)
 - Take out the cover of your remote controller
-- Loose the screws of AB terminals. 
+- Loose the screws of AB terminals.
 - Wire the remote A,B terminals to the pcb. V1 board is polarity sensitive. V3 board can be connected both ways.
   - **Set the Power Selector to AB**
 
@@ -206,7 +206,7 @@ https://github.com/makusets/esphome-toshiba-ab/tree/main/hardware
 
 # Case
 
-A suitable enclosure for the board was designed to be 3D printed in two parts, STL files are available in the hardware folder. The case was designed using OnShape online designing software, the original file is public and can be found and modified by searching "toshiba_esp_case" within OnShape environment. 
+A suitable enclosure for the board was designed to be 3D printed in two parts, STL files are available in the hardware folder. The case was designed using OnShape online designing software, the original file is public and can be found and modified by searching "toshiba_esp_case" within OnShape environment.
 The case looks like this:
 
 <img src="hardware/v3/toshiba_top_case.png" width="49%"> <img src="hardware/v3/toshiba_bot_case.png" width="49%">


### PR DESCRIPTION
### Motivation
- Ensure every cited GitHub username in the repository `README.md` is a clickable link to the user's GitHub profile to improve attribution and navigation.

### Description
- Converted inline mentions like `@7tobias`, `@vakkeli`, `@mtthidoteu`, `@issalig`, and `@muxa` to Markdown links pointing to `https://github.com/<user>` in `README.md`.
- Trimmed trailing whitespace and normalized some line endings in `README.md` while making the replacements.
- Saved and committed the updated `README.md`.

### Testing
- Ran a Python regex check that verified no unlinked `@user` mentions remain, and it succeeded.
- Ran `git diff --check` to detect whitespace issues, fixed trailing whitespace, and re-ran which then passed.
- Attempted `markdownlint README.md`, but `markdownlint` was not installed in the environment so that check could not be run successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e0ca44048832fa7fb721e7c1df43b)