### PR TITLE
Handle normal TCC-Link frame restart indicator

### DIFF
--- a/components/toshiba_ab/toshiba_ab.h
+++ b/components/toshiba_ab/toshiba_ab.h
@@ -482,6 +482,15 @@ struct DataFrameReader {
       ESP_LOGV("READER", "Ignoring packet with out-of-range source: 0x%02X", current_byte);
       return false;
     }
+    // In classic TCC-Link, some units restart a frame in-place and mark the
+    // abandoned frame by sending 0x00 as the 6th byte. Discard the partial
+    // frame so the following byte is read as a new source byte.
+    if (frame_format_ == FrameFormat::NORMAL && data_index_ == 5 && current_byte == 0x00) {
+      ESP_LOGV("READER", "Normal TCC-Link frame restart indicator at byte 6; resetting reader");
+      reset_frame_state_();
+      return false;
+    }
+
     // Store byte
     frame.raw[data_index_] = current_byte;
 


### PR DESCRIPTION
### Motivation
- Some classic TCC-Link units abandon a partially-received frame and mark the restart by sending `0x00` as the 6th byte, which breaks the reader state machine if unhandled.

### Description
- Add a detection in `DataFrameReader::put` to treat a `0x00` seen at byte index 5 for `FrameFormat::NORMAL` as a restart indicator and call `reset_frame_state_()` so the subsequent byte is treated as a new source byte.
- Emit a verbose log when this restart indicator is detected and keep behavior localised to `components/toshiba_ab/toshiba_ab.h` so other frame formats (TU2C/A0/HM) are unaffected.

### Testing
- Ran `git diff --check` to ensure no whitespace/errors reported, which succeeded.
- Executed a Python assertion that checks the restart-indicator code is present in `components/toshiba_ab/toshiba_ab.h`, which succeeded.
- Ran `clang-format` on the modified file to normalise formatting, which completed; attempted `platformio` build with `python3 -m platformio` but it failed because `platformio` is not installed in the environment (build not run here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26661afb58832f85831aae1ad22f9e)