### PR TITLE
Support 5th-byte restart marker for normal TCC-Link frames

### DIFF
--- a/components/toshiba_ab/toshiba_ab.h
+++ b/components/toshiba_ab/toshiba_ab.h
@@ -483,10 +483,12 @@ struct DataFrameReader {
       return false;
     }
     // In classic TCC-Link, some units restart a frame in-place and mark the
-    // abandoned frame by sending 0x00 as the 6th byte. Discard the partial
-    // frame so the following byte is read as a new source byte.
-    if (frame_format_ == FrameFormat::NORMAL && data_index_ == 5 && current_byte == 0x00) {
-      ESP_LOGV("READER", "Normal TCC-Link frame restart indicator at byte 6; resetting reader");
+    // abandoned frame by sending 0x00 as the 5th or 6th byte. Discard the
+    // partial frame so the following byte is read as a new source byte.
+    if (frame_format_ == FrameFormat::NORMAL &&
+        (data_index_ == 4 || data_index_ == 5) && current_byte == 0x00) {
+      ESP_LOGV("READER", "Normal TCC-Link frame restart indicator at byte %u; resetting reader",
+               static_cast<unsigned>(data_index_ + 1));
       reset_frame_state_();
       return false;
     }


### PR DESCRIPTION
### Motivation
- Some TCC‑Link units mark an in-place frame restart by sending `0x00` in the 5th byte as well as the 6th, so the reader should discard the partial frame when either occurs to resync reliably.

### Description
- Update `DataFrameReader` in `components/toshiba_ab/toshiba_ab.h` to treat `data_index_ == 4` or `data_index_ == 5` with `current_byte == 0x00` as a restart indicator and call `reset_frame_state_()`, and change the verbose log to report the 1-based byte position via `data_index_ + 1`.

### Testing
- Ran `git diff --check` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a266cbfb74c832f85b38bee0b3f82ef)