### PR TITLE
toshiba_ab: add configurable `packet_min_wait` to guard against bus collisions

### DIFF
--- a/complete_example.yaml
+++ b/complete_example.yaml
@@ -79,6 +79,10 @@ climate:
     frame_format: N             # optional, defaults to autodetect, otherwise can be forced to "n" for TCC-Link, or "hm" for Estia HM variant, use "U" if your unit uses TU2C protocol, check parity in UART section too
     filter_frames: true         # optional, default true; reject normal TCC-Link frames with source > 0xA0
 
+    # --- Bus collision guard ---
+    packet_min_wait: 200ms      # optional, default 200ms; minimum idle time after received bytes before the next packet is parsed
+                                # Increase if you still see bus/data collisions; lower only if your bus needs faster packet processing
+
     ###### Optional settings  #######
 
     filter_alert:               # Optional binary sensor to report filter alert status if available

--- a/components/toshiba_ab/climate.py
+++ b/components/toshiba_ab/climate.py
@@ -47,6 +47,7 @@ CONF_COMMAND_MODE_READ = "command_mode_read"
 CONF_COMMAND_MODE_WRITE = "command_mode_write"
 CONF_FRAME_FORMAT = "frame_format"
 CONF_FILTER_FRAMES = "filter_frames"
+CONF_PACKET_MIN_WAIT = "packet_min_wait"
 CONF_FRAME = "frame"
 
 CONF_AUTONOMOUS = "autonomous"
@@ -163,6 +164,7 @@ CONFIG_SCHEMA = climate._CLIMATE_SCHEMA.extend(
         cv.Optional(CONF_COMMAND_MODE_WRITE, default=0x80): cv.uint8_t,
         cv.Optional(CONF_FRAME_FORMAT, default="auto"): cv.one_of(*FRAME_FORMATS, lower=True),
         cv.Optional(CONF_FILTER_FRAMES, default=True): cv.boolean,
+        cv.Optional(CONF_PACKET_MIN_WAIT, default="200ms"): cv.positive_time_period_milliseconds,
         # Manual override for hardware UART0 RX. The common ESP8266 case
         # (uart.rx_pin GPIO13 with a non-UART0 TX pin) is auto-detected below.
         cv.Optional(CONF_HARDWARE_UART_RX_PIN): _hardware_uart_rx_pin,
@@ -320,6 +322,8 @@ async def to_code(config):
             cg.add(var.set_frame_format(FRAME_FORMATS[config[CONF_FRAME_FORMAT]]))
     if CONF_FILTER_FRAMES in config:
         cg.add(var.set_filter_frames(config[CONF_FILTER_FRAMES]))
+    if CONF_PACKET_MIN_WAIT in config:
+        cg.add(var.set_packet_min_wait(cg.uint32(config[CONF_PACKET_MIN_WAIT])))
     if CONF_HARDWARE_UART_RX_PIN in config:
         cg.add(var.set_hardware_uart_rx_pin(config[CONF_HARDWARE_UART_RX_PIN]))
 

--- a/components/toshiba_ab/toshiba_ab.cpp
+++ b/components/toshiba_ab/toshiba_ab.cpp
@@ -1150,6 +1150,7 @@ void ToshibaAbClimate::dump_config() {
   }
 #endif
   ESP_LOGCONFIG(TAG, "  Filter frames: %s", this->filter_frames_ ? "true" : "false");
+  ESP_LOGCONFIG(TAG, "  Packet min wait: %" PRIu32 "ms", this->packet_min_wait_millis_);
   ESP_LOGCONFIG(TAG, "  Autonomous mode: %s", this->autonomous_ ? "true" : "false");
   ESP_LOGCONFIG(TAG, "  Read only: %s", this->read_only_ ? "true" : "false");
   const bool has_ext_temp = this->ext_temp_sensor_ != nullptr;
@@ -2514,7 +2515,7 @@ void ToshibaAbClimate::loop() {
 
     if (last_read_millis_ > 0) {
       auto millis_since_last_read = millis() - last_read_millis_;
-      if (millis_since_last_read >= PACKET_MIN_WAIT_MILLIS) {
+      if (millis_since_last_read >= this->packet_min_wait_millis_) {
         // can start reading packet
 
         if (!data_reader.complete && data_reader.data_index_ > 0) {

--- a/components/toshiba_ab/toshiba_ab.h
+++ b/components/toshiba_ab/toshiba_ab.h
@@ -830,6 +830,7 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
     data_reader.set_filter_frames(filter_frames);
   }
   bool get_filter_frames() const { return filter_frames_; }
+  void set_packet_min_wait(uint32_t millis) { packet_min_wait_millis_ = millis; }
   void set_command_mode_read(uint8_t value) { command_mode_read_ = value; }
   void set_command_mode_write(uint8_t value) { command_mode_write_ = value; }
   void set_filter_alert_sensor(binary_sensor::BinarySensor *sensor) { filter_alert_sensor_ = sensor; }
@@ -1034,6 +1035,7 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
   uint32_t loops_with_reads_ = 0;
   uint32_t last_read_millis_ = 0;
   uint32_t last_sent_millis_ = 0;
+  uint32_t packet_min_wait_millis_{PACKET_MIN_WAIT_MILLIS};
   uint32_t last_received_millis_ = 0;
   bool can_read_packet = false;
 


### PR DESCRIPTION
### Motivation

- Provide a configurable minimum idle time between received bytes to reduce bus/data collisions on shared TCC-Link/Estia/TU2C buses.

### Description

- Add new config option `packet_min_wait` (default `200ms`) to the `toshiba_ab` climate component and update `complete_example.yaml` with documentation and comments for the option. 
- Expose `CONF_PACKET_MIN_WAIT` in `climate.py` schema and pass the value to the component via the new `set_packet_min_wait` setter.
- Add `packet_min_wait_millis_` member and default initialization, use it in the main loop to gate packet parsing instead of the hardcoded `PACKET_MIN_WAIT_MILLIS`, and log the configured value in `dump_config()`.

### Testing

- Validated the YAML schema with `esphome config` against the updated `complete_example.yaml`, which succeeded. 
- Performed a local build for the target device using `platformio run` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26875b2d3c832fb17179326967eb8d)