### PR TITLE
Add optional ping keep-alive and address confirmation flags to Toshiba AB climate

### DIFF
--- a/components/toshiba_ab/climate.py
+++ b/components/toshiba_ab/climate.py
@@ -52,6 +52,7 @@ CONF_FRAME = "frame"
 
 CONF_AUTONOMOUS = "autonomous"
 CONF_READ_ONLY = "read_only"
+CONF_PING = "ping"
 
 # Estia-specific sensors
 CONF_OUTDOOR_TEMPERATURE = "outdoor_temperature"
@@ -206,6 +207,7 @@ CONFIG_SCHEMA = climate._CLIMATE_SCHEMA.extend(
         ),
         cv.Optional(CONF_AUTONOMOUS, default=False): cv.boolean,
         cv.Optional(CONF_READ_ONLY, default=False): cv.boolean,
+        cv.Optional(CONF_PING, default=True): cv.boolean,
         cv.Optional(CONF_SENSORS, default=[]): cv.ensure_list(SENSOR_ITEM_SCHEMA),
         cv.Optional(CONF_REPORT_SENSOR_TEMP): REPORT_SENSOR_TEMP_SCHEMA,
         cv.Optional(CONF_FILTER_ALERT): binary_sensor.binary_sensor_schema(),
@@ -352,6 +354,8 @@ async def to_code(config):
         cg.add(var.set_autonomous(config[CONF_AUTONOMOUS]))
     if CONF_READ_ONLY in config:
         cg.add(var.set_read_only(config[CONF_READ_ONLY]))
+    if CONF_PING in config:
+        cg.add(var.set_ping_enabled(config[CONF_PING]))
     
     if CONF_FILTER_ALERT in config:
         sens = await binary_sensor.new_binary_sensor(config[CONF_FILTER_ALERT])

--- a/components/toshiba_ab/toshiba_ab.cpp
+++ b/components/toshiba_ab/toshiba_ab.cpp
@@ -1120,6 +1120,7 @@ void ToshibaAbClimate::dump_config() {
   this->dump_traits_(TAG);
   ESP_LOGCONFIG(TAG, "  Remote address: 0x%02X", this->remote_address_);
   ESP_LOGCONFIG(TAG, "  Master address: 0x%02X", this->master_address_);
+  ESP_LOGCONFIG(TAG, "  Master address confirmed: %s", this->master_address_confirmed_ ? "true" : "false");
   ESP_LOGCONFIG(TAG, "  Master address auto: %s", this->master_address_auto_ ? "true" : "false");
   ESP_LOGCONFIG(TAG, "  Command mode read: 0x%02X", this->command_mode_read_);
   ESP_LOGCONFIG(TAG, "  Command mode write: 0x%02X", this->command_mode_write_);
@@ -1152,6 +1153,7 @@ void ToshibaAbClimate::dump_config() {
   ESP_LOGCONFIG(TAG, "  Filter frames: %s", this->filter_frames_ ? "true" : "false");
   ESP_LOGCONFIG(TAG, "  Packet min wait: %" PRIu32 "ms", this->packet_min_wait_millis_);
   ESP_LOGCONFIG(TAG, "  Autonomous mode: %s", this->autonomous_ ? "true" : "false");
+  ESP_LOGCONFIG(TAG, "  Ping: %s", this->ping_enabled_ ? "true" : "false");
   ESP_LOGCONFIG(TAG, "  Read only: %s", this->read_only_ ? "true" : "false");
   const bool has_ext_temp = this->ext_temp_sensor_ != nullptr;
   ESP_LOGCONFIG(TAG, "  External temp report: %s", (has_ext_temp && this->ext_temp_enabled_) ? "enabled" : "disabled");
@@ -1292,6 +1294,22 @@ void ToshibaAbClimate::setup() {
         }
       });
     }
+  } else if (this->ping_enabled_) {
+    this->set_interval(this->ping_interval_ms_, [this]() {
+      if (this->data_reader.frame_format() != FrameFormat::NORMAL) {
+        return;
+      }
+      if (!this->remote_address_confirmed_) {
+        ESP_LOGV(TAG, "Ping skipped: remote address is not confirmed yet");
+        return;
+      }
+      if (!this->master_address_confirmed_) {
+        ESP_LOGV(TAG, "Ping skipped: master address is not confirmed yet");
+        return;
+      }
+      this->send_ping();
+      ESP_LOGV(TAG, "Enqueued remote PING (keep-alive)");
+    });
   }
 
   this->update_frame_validation_();
@@ -1393,6 +1411,10 @@ void ToshibaAbClimate::sync_from_received_state() {
 
 void ToshibaAbClimate::process_received_data(const struct DataFrame *frame) {
   if (frame->source == this->master_address_) {
+      if (!this->master_address_confirmed_) {
+        this->master_address_confirmed_ = true;
+        ESP_LOGI(TAG, "Master address confirmed from valid frame: 0x%02X", this->master_address_);
+      }
       // status update
       ESP_LOGD(TAG, "Received data from master:");
       last_master_alive_millis_ = millis();
@@ -1544,7 +1566,8 @@ void ToshibaAbClimate::process_received_data(const struct DataFrame *frame) {
           this->remote_address_ < TOSHIBA_REMOTE_MAX) {
         const uint8_t old = this->remote_address_;
         this->remote_address_++;
-        ESP_LOGI(TAG, "Remote auto-address collision detected at 0x%02X; switching to 0x%02X",
+        this->remote_address_confirmed_ = true;
+        ESP_LOGI(TAG, "Remote auto-address collision detected at 0x%02X; switching to confirmed address 0x%02X",
                  old, this->remote_address_);
       }
       ESP_LOGD(TAG, "Received data from remote:");
@@ -1576,6 +1599,7 @@ void ToshibaAbClimate::process_received_data(const struct DataFrame *frame) {
         frame->dest != this->master_address_) {
           ESP_LOGI(TAG, "Remote ping addressed to new master: 0x%02X, updating master address", frame->dest);
           this->master_address_ = frame->dest;
+          this->master_address_confirmed_ = false;
         }
       
       // Remote 40:00:15:06:08:E8:00:01:00:9E:2C that is sent every minute, the master responds with an hourly counter (time on?)
@@ -3052,6 +3076,7 @@ void ToshibaAbReadOnlySwitch::write_state(bool state) {
 
 void ToshibaAbClimate::set_master_address(uint8_t address) {
   this->master_address_ = address;
+  this->master_address_confirmed_ = false;
 }
 
 }  // namespace toshiba_ab

--- a/components/toshiba_ab/toshiba_ab.h
+++ b/components/toshiba_ab/toshiba_ab.h
@@ -810,8 +810,10 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
   void loop() override;
 
   uint8_t master_address_ = 0x00;
+  bool master_address_confirmed_{false};
   uint8_t remote_address_{TOSHIBA_REMOTE_DEFAULT};
   bool remote_address_auto_{true};
+  bool remote_address_confirmed_{false};
   bool master_address_auto_{true};
   uint8_t tu2c_remote_address_{TOSHIBA_TU2C_REMOTE_DEFAULT};
   uint8_t tu2c_master_address_{TOSHIBA_TU2C_MASTER_DEFAULT};
@@ -820,6 +822,7 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
   void set_remote_address(uint8_t address) {
     remote_address_ = std::min(address, TOSHIBA_REMOTE_MAX);
     remote_address_auto_ = false;
+    remote_address_confirmed_ = true;
   }
   void set_master_address_auto(bool auto_detect) {
     master_address_auto_ = auto_detect;
@@ -889,6 +892,7 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
   bool is_tu2c_registration_ack_(const DataFrame *frame) const;
   bool is_tu2c_registration_query_(const DataFrame &frame) const;
   void set_read_only(bool en) { read_only_ = en; }
+  void set_ping_enabled(bool en) { ping_enabled_ = en; }
   void set_estia_source_address(uint16_t addr) { estia_source_address_ = addr; }
   void send_estia_setpoint(float target_temp);
   void send_estia_power(bool on);
@@ -1022,6 +1026,7 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
   // If true, component will not send any commands to the central unit
   // (useful for read-only deployments). Default: false
   bool read_only_{false};
+  bool ping_enabled_{true};
 
   //autonomous mode **********************************
   bool autonomous_ = false;


### PR DESCRIPTION
### Motivation
- Add optional periodic "ping" keep-alive when not using autonomous mode to keep the Toshiba bus active. 
- Improve reliability by tracking confirmation state of configured remote and master addresses so the component avoids sending pings/commands until addresses are verified. 

### Description
- Add new config option `ping` (`CONF_PING`) with default `true` and expose it via `set_ping_enabled()` and `ping_enabled_` member. 
- When not in autonomous mode and `ping` is enabled, schedule a periodic ping every `ping_interval_ms_` that only runs when the detected frame format is normal and both `remote_address_confirmed_` and `master_address_confirmed_` are true. 
- Track address confirmation state with two new flags `master_address_confirmed_` and `remote_address_confirmed_` that are set/cleared in `process_received_data()`, `set_master_address()` and `set_remote_address()` and when the master address is auto-updated from remote pings. 
- Update `dump_config()` logging to show the new `Ping` and `Master address confirmed` status and adjust some log messages to reflect address confirmation semantics. 

### Testing
- Performed a local firmware build of the component with PlatformIO to validate compilation; build succeeded. 
- Ran repository static checks/linting for the modified files; checks passed. 
- There are no component-specific automated unit tests in the repo, so behavior was validated via compilation and static checks only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3282451c68832f8b21e3db5386b28b)