### PR TITLE
Add autoreset handling for remote error reports

### DIFF
--- a/components/toshiba_ab/climate.py
+++ b/components/toshiba_ab/climate.py
@@ -48,6 +48,7 @@ CONF_COMMAND_MODE_WRITE = "command_mode_write"
 CONF_FRAME_FORMAT = "frame_format"
 CONF_FILTER_FRAMES = "filter_frames"
 CONF_PACKET_MIN_WAIT = "packet_min_wait"
+CONF_AUTORESET_ERRORS = "autoreset_errors"
 CONF_FRAME = "frame"
 
 CONF_AUTONOMOUS = "autonomous"
@@ -166,6 +167,7 @@ CONFIG_SCHEMA = climate._CLIMATE_SCHEMA.extend(
         cv.Optional(CONF_FRAME_FORMAT, default="auto"): cv.one_of(*FRAME_FORMATS, lower=True),
         cv.Optional(CONF_FILTER_FRAMES, default=True): cv.boolean,
         cv.Optional(CONF_PACKET_MIN_WAIT, default="200ms"): cv.positive_time_period_milliseconds,
+        cv.Optional(CONF_AUTORESET_ERRORS, default=False): cv.boolean,
         # Manual override for hardware UART0 RX. The common ESP8266 case
         # (uart.rx_pin GPIO13 with a non-UART0 TX pin) is auto-detected below.
         cv.Optional(CONF_HARDWARE_UART_RX_PIN): _hardware_uart_rx_pin,
@@ -326,6 +328,8 @@ async def to_code(config):
         cg.add(var.set_filter_frames(config[CONF_FILTER_FRAMES]))
     if CONF_PACKET_MIN_WAIT in config:
         cg.add(var.set_packet_min_wait(cg.uint32(config[CONF_PACKET_MIN_WAIT])))
+    if CONF_AUTORESET_ERRORS in config:
+        cg.add(var.set_autoreset_errors(config[CONF_AUTORESET_ERRORS]))
     if CONF_HARDWARE_UART_RX_PIN in config:
         cg.add(var.set_hardware_uart_rx_pin(config[CONF_HARDWARE_UART_RX_PIN]))
 

--- a/components/toshiba_ab/toshiba_ab.cpp
+++ b/components/toshiba_ab/toshiba_ab.cpp
@@ -1409,6 +1409,19 @@ void ToshibaAbClimate::sync_from_received_state() {
   }
 }
 
+void ToshibaAbClimate::autoreset_remote_error_() {
+  ESP_LOGI(TAG, "Autoreset errors: resending current mode/fan/target temperature");
+  auto command = DataFrame{};
+  if (this->data_reader.frame_format() == FrameFormat::TU2C) {
+    write_set_parameter_flags_tu2c(&command, this->tu2c_remote_address_, this->tu2c_master_address_, &this->tcc_state,
+                                   COMMAND_SET_TEMP | COMMAND_SET_FAN);
+  } else {
+    write_set_parameter_flags(&command, this->remote_address_, this->master_address_, this->command_mode_read_, &this->tcc_state,
+                              COMMAND_SET_TEMP | COMMAND_SET_FAN, this->is_hm_variant());
+  }
+  this->send_command(command);
+}
+
 void ToshibaAbClimate::process_received_data(const struct DataFrame *frame) {
   if (frame->source == this->master_address_) {
       if (!this->master_address_confirmed_) {
@@ -1585,6 +1598,17 @@ void ToshibaAbClimate::process_received_data(const struct DataFrame *frame) {
         // sync_from_received_state(); we don't update the state, we wait for the next status update from master
         // remote temperature is sent regardless of DN32 setting, ac decides wether to use it or ignore it
         
+
+      // Remote error report: 40 FE 55 02 0E 49 AE
+      } else if (frame->opcode1 == OPCODE_TEMPERATURE &&
+                 frame->data_length == 2 &&
+                 frame->data[1] == 0x49) {
+        log_data_frame("Remote error report", frame);
+        if (this->autoreset_errors_) {
+          this->autoreset_remote_error_();
+        } else {
+          ESP_LOGD(TAG, "Ignoring remote error report because autoreset_errors is disabled");
+        }
 
       // Remote PING sent every 30s: 40 00 15 07 08 0C 81 00 00 48 00 ..
       } else if (frame->opcode1 == OPCODE_ERROR_HISTORY &&      // 0x15 envelope

--- a/components/toshiba_ab/toshiba_ab.h
+++ b/components/toshiba_ab/toshiba_ab.h
@@ -893,6 +893,7 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
   bool is_tu2c_registration_query_(const DataFrame &frame) const;
   void set_read_only(bool en) { read_only_ = en; }
   void set_ping_enabled(bool en) { ping_enabled_ = en; }
+  void set_autoreset_errors(bool en) { autoreset_errors_ = en; }
   void set_estia_source_address(uint16_t addr) { estia_source_address_ = addr; }
   void send_estia_setpoint(float target_temp);
   void send_estia_power(bool on);
@@ -949,6 +950,7 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
   void handle_pending_command_ack_(const DataFrame *frame);
   size_t send_new_state(const struct TccState *new_state);
   void sync_from_received_state();
+  void autoreset_remote_error_();
   bool is_own_tx_echo_(const DataFrame *f) const; //used to filter echo after sending frame
   void remember_tx_frame_for_echo_(const uint8_t *bytes, size_t size, bool tu2c);
   void update_frame_validation_();
@@ -1027,6 +1029,7 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
   // (useful for read-only deployments). Default: false
   bool read_only_{false};
   bool ping_enabled_{true};
+  bool autoreset_errors_{false};
 
   //autonomous mode **********************************
   bool autonomous_ = false;


### PR DESCRIPTION
### Motivation
- Detect a specific remote error frame and optionally recover by re-sending the current operating command so the AC recovers without manual intervention.
- Expose the behavior as a YAML option so users can enable it when desired and keep default behavior unchanged.

### Description
- Added a new YAML option `autoreset_errors` (default `false`) and wired it into code generation via `to_code` to call `set_autoreset_errors` in `climate.py`.
- Added storage and setter (`set_autoreset_errors`) plus a `bool autoreset_errors_` member and a `autoreset_remote_error_()` helper in `toshiba_ab.h`/`.cpp` to hold and act on the option.
- Implemented detection of the remote error report as a frame with `opcode1 == OPCODE_TEMPERATURE (0x55)`, `data_length == 2`, and `data[1] == 0x49` inside `process_received_data`, logging the frame and conditionally calling `autoreset_remote_error_()`.
- `autoreset_remote_error_()` constructs and sends a `SET TEMP + FAN` command using `write_set_parameter_flags` or `write_set_parameter_flags_tu2c` with the current `tcc_state`, then calls `send_command` to bypass the no-change guard.

### Testing
- Ran `python3 -m py_compile components/toshiba_ab/climate.py` which succeeded.
- Ran `git diff --check` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32907e0ce4832f9a59166f5c139f5f)