### PR TITLE
Add first-generation Estia (R410A) protocol support (`frame_format: estia`)

### DIFF
--- a/components/toshiba_ab/climate.py
+++ b/components/toshiba_ab/climate.py
@@ -62,6 +62,10 @@ CONF_WATERPUMP_HOURS = "waterpump_hours"
 CONF_BACKUP_HEATER_HOURS = "backup_heater_hours"
 CONF_DEMAND = "demand"
 CONF_DEMAND_ENABLED = "demand_enabled"
+CONF_ZONE1_SWITCH = "zone1_switch"
+CONF_DHW_BOOST = "dhw_boost"
+CONF_ZONE1_WATER_TEMPERATURE = "zone1_water_temperature"
+CONF_ZONE1_CURVE = "zone1_curve"
 
 #AC Sensors addresses
 
@@ -89,6 +93,12 @@ ToshibaAbVentSwitch =  toshiba_ab_ns.class_(
 ToshibaAbReadOnlySwitch = toshiba_ab_ns.class_(
     "ToshibaAbReadOnlySwitch", switch.Switch, cg.Component
 )
+ToshibaAbEstiaZone1Switch = toshiba_ab_ns.class_(
+    "ToshibaAbEstiaZone1Switch", switch.Switch, cg.Component
+)
+ToshibaAbEstiaDhwBoostSwitch = toshiba_ab_ns.class_(
+    "ToshibaAbEstiaDhwBoostSwitch", switch.Switch, cg.Component
+)
 
 ToshibaAbOnDataReceivedTrigger = toshiba_ab_ns.class_(
     "ToshibaAbOnDataReceivedTrigger", automation.Trigger.template()
@@ -110,6 +120,7 @@ FRAME_FORMATS = {
     "a0": FrameFormat.A0,
     "estia_a0": FrameFormat.A0,
     "hm": FrameFormat.HM,
+    "estia": FrameFormat.ESTIA,
 }
 
 
@@ -190,6 +201,37 @@ CONFIG_SCHEMA = climate._CLIMATE_SCHEMA.extend(
                 )
             ),
             key=CONF_NAME,
+        ),
+
+        cv.Optional(CONF_ZONE1_SWITCH): cv.maybe_simple_value(
+            switch._SWITCH_SCHEMA.extend(
+                cv.Schema(
+                    {
+                        cv.GenerateID(): cv.declare_id(ToshibaAbEstiaZone1Switch),
+                    }
+                )
+            ),
+            key=CONF_NAME,
+        ),
+        cv.Optional(CONF_DHW_BOOST): cv.maybe_simple_value(
+            switch._SWITCH_SCHEMA.extend(
+                cv.Schema(
+                    {
+                        cv.GenerateID(): cv.declare_id(ToshibaAbEstiaDhwBoostSwitch),
+                    }
+                )
+            ),
+            key=CONF_NAME,
+        ),
+        cv.Optional(CONF_ZONE1_WATER_TEMPERATURE): sensor.sensor_schema(
+            unit_of_measurement=UNIT_CELSIUS,
+            accuracy_decimals=0,
+            device_class=DEVICE_CLASS_TEMPERATURE,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        cv.Optional(CONF_ZONE1_CURVE): sensor.sensor_schema(
+            accuracy_decimals=0,
+            state_class=STATE_CLASS_MEASUREMENT,
         ),
         cv.Optional(CONF_FAILED_CRCS): sensor.sensor_schema(
             accuracy_decimals=0,
@@ -341,6 +383,12 @@ async def to_code(config):
     if CONF_READ_ONLY_SWITCH in config:
         sw = await switch.new_switch(config[CONF_READ_ONLY_SWITCH], var)
         cg.add(var.set_read_only_switch(sw))
+    if CONF_ZONE1_SWITCH in config:
+        sw = await switch.new_switch(config[CONF_ZONE1_SWITCH], var)
+        cg.add(var.set_zone1_switch(sw))
+    if CONF_DHW_BOOST in config:
+        sw = await switch.new_switch(config[CONF_DHW_BOOST], var)
+        cg.add(var.set_dhw_boost_switch(sw))
 
     if CONF_ON_DATA_RECEIVED in config:
         for on_data_received in config.get(CONF_ON_DATA_RECEIVED, []):
@@ -360,6 +408,12 @@ async def to_code(config):
         cg.add(var.set_filter_alert_sensor(sens))
 
     # Estia sensors
+    if CONF_ZONE1_WATER_TEMPERATURE in config:
+        sens = await sensor.new_sensor(config[CONF_ZONE1_WATER_TEMPERATURE])
+        cg.add(var.set_zone1_water_temp_sensor(sens))
+    if CONF_ZONE1_CURVE in config:
+        sens = await sensor.new_sensor(config[CONF_ZONE1_CURVE])
+        cg.add(var.set_zone1_curve_sensor(sens))
     if CONF_OUTDOOR_TEMPERATURE in config:
         sens = await sensor.new_sensor(config[CONF_OUTDOOR_TEMPERATURE])
         cg.add(var.set_outdoor_temp_sensor(sens))

--- a/components/toshiba_ab/toshiba_ab.cpp
+++ b/components/toshiba_ab/toshiba_ab.cpp
@@ -191,6 +191,7 @@ void ToshibaAbClimate::confirm_frame_format_(FrameFormat format, const char *rea
     case FrameFormat::TU2C: fmt = "tu2c"; break;
     case FrameFormat::A0: fmt = "a0"; break;
     case FrameFormat::HM: fmt = "hm"; break;
+    case FrameFormat::ESTIA: fmt = "estia"; break;
     default: fmt = "n"; break;
   }
   ESP_LOGI(TAG, "Auto-detected frame_format=%s (%s)", fmt, reason != nullptr ? reason : "confirmed frame");
@@ -1129,6 +1130,7 @@ void ToshibaAbClimate::dump_config() {
     case FrameFormat::TU2C: fmt_label = "TU2C (U series)"; break;
     case FrameFormat::A0: fmt_label = "A0-protocol"; break;
     case FrameFormat::HM: fmt_label = "HM (RAV-RM/HM range)"; break;
+    case FrameFormat::ESTIA: fmt_label = "Estia first generation (R410A)"; break;
     default: fmt_label = "TCC-Link"; break;
   }
   ESP_LOGCONFIG(TAG, "  Frame format: %s%s%s", fmt_label, this->frame_format_auto_ ? " (auto" : "",
@@ -1189,12 +1191,12 @@ void ToshibaAbClimate::setup() {
   }
 
   // Override traits for Estia heat pump
-  if (this->data_reader.frame_format() == FrameFormat::A0) {
-    this->traits_.set_supported_modes({
-        climate::CLIMATE_MODE_OFF,
-        climate::CLIMATE_MODE_HEAT,
-        climate::CLIMATE_MODE_COOL,
-    });
+  if (this->data_reader.frame_format() == FrameFormat::A0 || this->data_reader.frame_format() == FrameFormat::ESTIA) {
+    if (this->data_reader.frame_format() == FrameFormat::ESTIA) {
+      this->traits_.set_supported_modes({climate::CLIMATE_MODE_OFF, climate::CLIMATE_MODE_HEAT});
+    } else {
+      this->traits_.set_supported_modes({climate::CLIMATE_MODE_OFF, climate::CLIMATE_MODE_HEAT, climate::CLIMATE_MODE_COOL});
+    }
     this->traits_.set_supported_fan_modes({});
     this->traits_.set_supported_swing_modes({});
     this->traits_.set_visual_min_temperature(20);
@@ -2282,7 +2284,11 @@ bool ToshibaAbClimate::receive_data_frame(const struct DataFrame *frame) {
   // still notify any listeners of real frames
   this->set_data_received_callback_.call(frame);
   if (frame->is_tu2c()) {
-    process_received_data_tu2c_(frame);
+    if (this->data_reader.frame_format() == FrameFormat::ESTIA) {
+      process_received_data_estia_first_gen_(frame);
+    } else {
+      process_received_data_tu2c_(frame);
+    }
   } else {
     process_received_data(frame);
   }
@@ -2675,6 +2681,21 @@ void ToshibaAbClimate::control(const climate::ClimateCall &call) {
   // Only one command at a time on the half-duplex AB-bus.
   // When powering on with a mode change, send mode first, then power on
   // after a delay so the WP starts in the correct mode.
+  if (this->data_reader.frame_format() == FrameFormat::ESTIA) {
+    if (call.get_mode().has_value()) {
+      auto new_mode = call.get_mode().value();
+      if (new_mode == climate::CLIMATE_MODE_OFF) {
+        this->send_estia_first_gen_dhw_boost(false);
+      } else {
+        this->send_estia_first_gen_dhw_boost(true);
+      }
+    }
+    if (call.get_target_temperature().has_value()) {
+      this->send_estia_first_gen_dhw_setpoint(call.get_target_temperature().value());
+    }
+    return;
+  }
+
   if (this->data_reader.frame_format() == FrameFormat::A0) {
     if (call.get_mode().has_value()) {
       ESP_LOGD(TAG, "Control: mode=%s", LOG_STR_ARG(climate::climate_mode_to_string(*call.get_mode())));
@@ -3083,6 +3104,114 @@ bool ToshibaAbClimate::control_vent(bool state) {
   TccState new_state = TccState{tcc_state};
   new_state.vent = state;
   return send_new_state(&new_state) > 0;
+}
+
+static uint8_t estia_first_gen_checksum(const uint8_t *frame, size_t len) {
+  uint16_t sum = 0;
+  if (len < 4) return 0;
+  for (size_t i = 2; i < len - 2; i++) sum += frame[i];
+  return static_cast<uint8_t>(sum & 0xFF);
+}
+
+static uint8_t estia_first_gen_raw_checksum(const uint8_t *raw, size_t raw_len) {
+  uint16_t sum = 0;
+  if (raw_len < 2) return 0;
+  for (size_t i = 0; i < raw_len - 1; i++) sum += raw[i];
+  return static_cast<uint8_t>(sum & 0xFF);
+}
+
+static std::vector<uint8_t> make_estia_first_gen_frame(uint8_t src, uint8_t dst, const uint8_t *payload, size_t payload_len) {
+  std::vector<uint8_t> frame;
+  frame.reserve(payload_len + 7);
+  frame.push_back(0xF0);
+  frame.push_back(0xF0);
+  frame.push_back(static_cast<uint8_t>(payload_len + 7));
+  frame.push_back(src);
+  frame.push_back(dst);
+  for (size_t i = 0; i < payload_len; i++) frame.push_back(payload[i]);
+  frame.push_back(0x00);
+  frame.push_back(0xA0);
+  frame[frame.size() - 2] = estia_first_gen_checksum(frame.data(), frame.size());
+  return frame;
+}
+
+void ToshibaAbClimate::send_estia_first_gen_zone1(bool on) {
+  if (this->read_only_) return;
+  const uint8_t payload[] = {0xE0, 0x01, 0x21, static_cast<uint8_t>(on ? 0x03 : 0x0A)};
+  this->raw_write_queue_.push(make_estia_first_gen_frame(this->remote_address_, this->master_address_, payload, sizeof(payload)));
+}
+
+void ToshibaAbClimate::send_estia_first_gen_dhw_boost(bool on) {
+  if (this->read_only_) return;
+  const uint8_t payload[] = {0xE0, 0x01, 0x21, static_cast<uint8_t>(on ? 0x0C : 0x08)};
+  this->raw_write_queue_.push(make_estia_first_gen_frame(this->remote_address_, this->master_address_, payload, sizeof(payload)));
+}
+
+void ToshibaAbClimate::send_estia_first_gen_dhw_setpoint(float target_temp) {
+  if (this->read_only_) return;
+  uint8_t encoded = static_cast<uint8_t>(std::round((target_temp + 16.0f) * 2.0f));
+  const uint8_t payload[] = {0xE0, 0x01, 0x23, 0x08, 0x00, 0x00, 0xA0, encoded};
+  this->raw_write_queue_.push(make_estia_first_gen_frame(this->remote_address_, this->master_address_, payload, sizeof(payload)));
+}
+
+void ToshibaAbClimate::send_estia_first_gen_request_data(uint8_t request_code) {
+  if (this->read_only_) return;
+  const uint8_t payload[] = {0xE0, 0x41, 0x5C, 0x70, request_code};
+  this->raw_write_queue_.push(make_estia_first_gen_frame(this->remote_address_, this->master_address_, payload, sizeof(payload)));
+}
+
+void ToshibaAbClimate::process_received_data_estia_first_gen_(const DataFrame *frame) {
+  if (frame == nullptr) return;
+  const uint8_t len = frame->raw[0];
+  const uint8_t raw_len = len > 3 ? len - 3 : 0;
+  if (len < 7 || raw_len > DATA_FRAME_MAX_SIZE) return;
+  if (frame->raw[raw_len - 1] != estia_first_gen_raw_checksum(frame->raw, raw_len)) {
+    ESP_LOGD(TAG, "Estia first-gen checksum fail");
+    return;
+  }
+  const uint8_t src = frame->raw[1];
+  const uint8_t dst = frame->raw[2];
+  if (this->master_address_auto_ && frame->raw[3] == 0xE0 && frame->raw[5] == 0x31) {
+    this->master_address_ = src;
+    this->master_address_confirmed_ = true;
+  }
+  if (this->remote_address_auto_ && src == this->remote_address_ && this->remote_address_ < TOSHIBA_ESTIA_REMOTE_MAX) {
+    this->remote_address_++;
+    ESP_LOGI(TAG, "Estia remote-address collision; switching to 0x%02X", this->remote_address_);
+  }
+  if (src == this->master_address_) {
+    this->last_master_alive_millis_ = millis();
+    if (this->connected_binary_sensor_) this->connected_binary_sensor_->publish_state(true);
+  }
+  if (src == this->master_address_ && frame->raw[3] == 0xE0 && frame->raw[5] == 0x31 && len > 11) {
+    this->estia_first_gen_zone1_active_ = frame->raw[6] & 0x01;
+    this->estia_first_gen_dhw_active_ = frame->raw[6] & 0x02;
+    this->estia_first_gen_dhw_boost_ = this->estia_first_gen_dhw_active_;
+    this->estia_first_gen_dhw_encoded_ = frame->raw[9];
+    this->estia_first_gen_zone1_encoded_ = frame->raw[10];
+    this->mode = this->estia_first_gen_dhw_active_ ? climate::CLIMATE_MODE_HEAT : climate::CLIMATE_MODE_OFF;
+    this->target_temperature = static_cast<float>(frame->raw[9]) / 2.0f - 16.0f;
+    this->current_temperature = this->target_temperature;
+    this->publish_state();
+    if (this->zone1_switch_) this->zone1_switch_->publish_state(this->estia_first_gen_zone1_active_);
+    if (this->dhw_boost_switch_) this->dhw_boost_switch_->publish_state(this->estia_first_gen_dhw_boost_);
+    if (this->zone1_curve_sensor_) this->zone1_curve_sensor_->publish_state(static_cast<float>(frame->raw[10]) / 2.0f - 16.0f);
+    if (len > 18 && this->zone1_water_temp_sensor_) this->zone1_water_temp_sensor_->publish_state(static_cast<float>(frame->raw[14]) / 2.0f - 16.0f);
+    this->estia_first_gen_pump_state_known_ = true;
+  } else if (src == this->master_address_ && frame->raw[4] == 0x80 && frame->raw[5] == 0x5C && len > 8) {
+    const uint16_t value = encode_uint16(frame->raw[6], frame->raw[7]);
+    if (this->outdoor_temp_sensor_) this->outdoor_temp_sensor_->publish_state(value);
+  } else {
+    log_raw_data("Estia first-gen", frame->raw, len);
+  }
+}
+
+void ToshibaAbEstiaZone1Switch::write_state(bool state) {
+  this->climate_->send_estia_first_gen_zone1(state);
+}
+
+void ToshibaAbEstiaDhwBoostSwitch::write_state(bool state) {
+  this->climate_->send_estia_first_gen_dhw_boost(state);
 }
 
 void ToshibaAbVentSwitch::write_state(bool state) {

--- a/components/toshiba_ab/toshiba_ab.h
+++ b/components/toshiba_ab/toshiba_ab.h
@@ -26,6 +26,9 @@ const uint8_t TOSHIBA_REMOTE_DEFAULT = 0x40;
 const uint8_t TOSHIBA_REMOTE_MAX = 0x49;
 const uint8_t TOSHIBA_TU2C_REMOTE_DEFAULT = 0x50;
 const uint8_t TOSHIBA_TU2C_MASTER_DEFAULT = 0x90;
+const uint8_t TOSHIBA_ESTIA_REMOTE_DEFAULT = 0x60;
+const uint8_t TOSHIBA_ESTIA_REMOTE_MAX = 0x69;
+const uint8_t TOSHIBA_ESTIA_MASTER_DEFAULT = 0x70;
 const uint8_t TOSHIBA_TEMP_SENSOR = 0x42;
 const uint8_t TOSHIBA_BROADCAST = 0xF0;
 const uint8_t TOSHIBA_REPORT = 0x52;
@@ -286,11 +289,13 @@ enum class FrameFormat : uint8_t {
   // unconditionally and crc_valid is set to false so callers can
   // distinguish if needed.
   HM = 3,
+  ESTIA = 4,
 };
 constexpr FrameFormat NORMAL = FrameFormat::NORMAL;
 constexpr FrameFormat TU2C = FrameFormat::TU2C;
 constexpr FrameFormat A0 = FrameFormat::A0;
 constexpr FrameFormat HM = FrameFormat::HM;
+constexpr FrameFormat ESTIA = FrameFormat::ESTIA;
 
 struct DataFrameReader {
   // Reads a data frame byte by byte, accumulating bytes until a complete frame is received
@@ -434,7 +439,7 @@ struct DataFrameReader {
       return false;
     }
 
-    const bool use_tu2c = frame_format_ == FrameFormat::TU2C;
+    const bool use_tu2c = frame_format_ == FrameFormat::TU2C || frame_format_ == FrameFormat::ESTIA;
     if (data_index_ == 0 && use_tu2c && !tu2c_) {
       if (prefix_match_ == 1) {
         if (byte == 0xF0) {
@@ -820,7 +825,7 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
   bool filter_frames_{true};
   void set_master_address(uint8_t address);
   void set_remote_address(uint8_t address) {
-    remote_address_ = std::min(address, TOSHIBA_REMOTE_MAX);
+    remote_address_ = std::min(address, static_cast<uint8_t>(TOSHIBA_ESTIA_REMOTE_MAX));
     remote_address_auto_ = false;
     remote_address_confirmed_ = true;
   }
@@ -842,10 +847,15 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
   void set_waterpump_hours_sensor(sensor::Sensor *sensor) { waterpump_hours_sensor_ = sensor; }
   void set_backup_heater_hours_sensor(sensor::Sensor *sensor) { backup_heater_hours_sensor_ = sensor; }
   void set_demand_sensor(sensor::Sensor *sensor) { demand_sensor_ = sensor; }
+  void set_zone1_water_temp_sensor(sensor::Sensor *sensor) { zone1_water_temp_sensor_ = sensor; }
+  void set_zone1_curve_sensor(sensor::Sensor *sensor) { zone1_curve_sensor_ = sensor; }
   void set_frame_format(FrameFormat format) {
     data_reader.set_frame_format(format);
     frame_format_auto_ = false;
     frame_format_confirmed_ = true;
+    if (format == FrameFormat::ESTIA) {
+      if (remote_address_auto_) remote_address_ = TOSHIBA_ESTIA_REMOTE_DEFAULT;
+    }
   }
   void set_frame_format_auto() {
     data_reader.set_frame_format(FrameFormat::NORMAL);
@@ -853,6 +863,7 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
     frame_format_confirmed_ = false;
   }
   bool is_hm_variant() const { return data_reader.frame_format() == FrameFormat::HM; }
+  bool is_estia_first_gen() const { return data_reader.frame_format() == FrameFormat::ESTIA; }
 
   // ESP8266 only: receive on the hardware UART0 using `pin` (auto-detected for
   // GPIO13, or explicitly configured for GPIO3/GPIO13) instead of ESPHome's
@@ -875,6 +886,8 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
   void set_vent_switch(switch_::Switch *vent_switch) { vent_switch_ = vent_switch; }
 
   void set_read_only_switch(switch_::Switch *read_only_switch) { read_only_switch_ = read_only_switch; }
+  void set_zone1_switch(switch_::Switch *zone1_switch) { zone1_switch_ = zone1_switch; }
+  void set_dhw_boost_switch(switch_::Switch *dhw_boost_switch) { dhw_boost_switch_ = dhw_boost_switch; }
 
   void set_failed_crcs_sensor(sensor::Sensor *failed_crcs_sensor) { this->failed_crcs_sensor_ = failed_crcs_sensor; }
 
@@ -902,6 +915,10 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
   void send_estia_demand_heartbeat();      // periodic 0x55 as 0x0041
   void set_demand_enabled(bool en) { demand_enabled_ = en; }
   void send_estia_data_request(uint8_t subtype);
+  void send_estia_first_gen_dhw_setpoint(float target_temp);
+  void send_estia_first_gen_zone1(bool on);
+  void send_estia_first_gen_dhw_boost(bool on);
+  void send_estia_first_gen_request_data(uint8_t request_code);
   void send_estia_tracked_(const uint8_t *frame, size_t len, uint16_t ack_dtype);
   
   // Reporting external sensor temperature to AC *************************
@@ -943,6 +960,7 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
 
   void process_received_data(const struct DataFrame *frame);
   void process_received_data_tu2c_(const struct DataFrame *frame);
+  void process_received_data_estia_first_gen_(const DataFrame *frame);
   bool is_ack_for_pending_command_(const DataFrame *frame) const;
   bool is_tu2c_command_ack_frame_(const DataFrame *frame) const;
   bool should_track_tu2c_command_ack_(const DataFrame &frame) const;
@@ -974,6 +992,8 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
   binary_sensor::BinarySensor *connected_binary_sensor_{nullptr};
   switch_::Switch *vent_switch_{nullptr};
   switch_::Switch *read_only_switch_{nullptr};
+  switch_::Switch *zone1_switch_{nullptr};
+  switch_::Switch *dhw_boost_switch_{nullptr};
   sensor::Sensor *failed_crcs_sensor_{nullptr};
 
   sensor::Sensor *current_sensor_{nullptr}; // Sensor for current, x10 A
@@ -984,6 +1004,8 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
   sensor::Sensor *waterpump_hours_sensor_{nullptr};
   sensor::Sensor *backup_heater_hours_sensor_{nullptr};
   sensor::Sensor *demand_sensor_{nullptr};  // 0-10V interface demand (0..15)
+  sensor::Sensor *zone1_water_temp_sensor_{nullptr};
+  sensor::Sensor *zone1_curve_sensor_{nullptr};
 
   // rx handler for 0x1A (sensor) replies (called from process_received_data)
   void process_sensor_value_(const DataFrame *frame);
@@ -1101,6 +1123,12 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
   uint8_t estia_demand_value_{0};         // current demand value (0..15)
   uint32_t estia_last_demand_heartbeat_ms_{0};
 
+  bool estia_first_gen_pump_state_known_{false};
+  bool estia_first_gen_zone1_active_{false};
+  bool estia_first_gen_dhw_active_{false};
+  bool estia_first_gen_dhw_boost_{false};
+  uint8_t estia_first_gen_dhw_encoded_{0};
+  uint8_t estia_first_gen_zone1_encoded_{0};
   uint32_t last_temp_log_time_ = 0;  // Counter for BME280 temperature logging
   float last_sent_temp_ = 1; // Last sent room temperature to the unit
 
@@ -1123,6 +1151,22 @@ class ToshibaAbVentSwitch : public switch_::Switch, public Component {
 
   void write_state(bool state) override;
 
+  ToshibaAbClimate *climate_;
+};
+
+class ToshibaAbEstiaZone1Switch : public switch_::Switch, public Component {
+ public:
+  ToshibaAbEstiaZone1Switch(ToshibaAbClimate *climate) { climate_ = climate; }
+ protected:
+  void write_state(bool state) override;
+  ToshibaAbClimate *climate_;
+};
+
+class ToshibaAbEstiaDhwBoostSwitch : public switch_::Switch, public Component {
+ public:
+  ToshibaAbEstiaDhwBoostSwitch(ToshibaAbClimate *climate) { climate_ = climate; }
+ protected:
+  void write_state(bool state) override;
   ToshibaAbClimate *climate_;
 };
 


### PR DESCRIPTION
### Motivation
- Add support for the first-generation Toshiba Estia (R410A) protocol variant seen in `makusets/toshiba_uart_ctrl` so the component can control older Estia pumps. 
- Make master and remote addressing configurable with sensible `auto` behaviour and avoid hardcoded full frames by building frames programmatically. 
- Expose domestic hot water (DHW) thermostat/boost control and Zone 1 control/sensors required by these older units.

### Description
- Added a new frame format enum `ESTIA` and YAML option `frame_format: estia` in `components/toshiba_ab/climate.py` and mapped it into the existing auto-detection pipeline. 
- Introduced Estia-specific address constants (`TOSHIBA_ESTIA_REMOTE_DEFAULT`, `TOSHIBA_ESTIA_REMOTE_MAX`, `TOSHIBA_ESTIA_MASTER_DEFAULT`) and made the component set Estia remote defaults when `ESTIA` is selected; remote auto-address collisions advance within `0x60..0x69`. 
- Reused the wrapped `0xF0 0xF0 ... 0xA0` reader path for ESTIA frames and dispatch ESTIA frames to a dedicated parser `process_received_data_estia_first_gen_`. 
- Implemented dynamic first-gen frame builders and checksum helpers (`make_estia_first_gen_frame`, `estia_first_gen_raw_checksum`) and APIs: `send_estia_first_gen_dhw_setpoint()`, `send_estia_first_gen_dhw_boost()`, `send_estia_first_gen_zone1()`, `send_estia_first_gen_request_data()` to build frames instead of hardcoding full message arrays. 
- Added parsing to decode pump status frames (autodetect master, publish connectivity), update a DHW-only climate state (heat/off) and target temperature, and publish Zone 1 switch state plus Zone 1 water/curve sensors; added YAML options and wiring for `zone1_switch`, `dhw_boost`, `zone1_water_temperature`, and `zone1_curve` in `climate.py`. 
- Routed TU2C/wrapped frames to the ESTIA handler when `frame_format` is `estia` and integrated the new switch write handlers to call the climate send functions.

### Testing
- `python3 -m py_compile components/toshiba_ab/climate.py` ran successfully. 
- Ran `git diff --check` as a quick syntax/style safety check with no reported issues. 
- Attempted a C++ syntax-only check (`g++ -std=c++17 -fsyntax-only components/toshiba_ab/toshiba_ab.cpp`), but full compilation is blocked in this environment due to missing ESPHome headers (CI/build environment should validate C++ compilation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e3b13b334832f819f894ef9f7f19b)