### PR TITLE
Rename Estia zone1 sensor to `zone1_target_temperature`

### DIFF
--- a/components/toshiba_ab/climate.py
+++ b/components/toshiba_ab/climate.py
@@ -65,7 +65,7 @@ CONF_DEMAND_ENABLED = "demand_enabled"
 CONF_ZONE1_SWITCH = "zone1_switch"
 CONF_DHW_BOOST = "dhw_boost"
 CONF_ZONE1_WATER_TEMPERATURE = "zone1_water_temperature"
-CONF_ZONE1_CURVE = "zone1_curve"
+CONF_ZONE1_TARGET_TEMPERATURE = "zone1_target_temperature"
 
 #AC Sensors addresses
 
@@ -229,8 +229,10 @@ CONFIG_SCHEMA = climate._CLIMATE_SCHEMA.extend(
             device_class=DEVICE_CLASS_TEMPERATURE,
             state_class=STATE_CLASS_MEASUREMENT,
         ),
-        cv.Optional(CONF_ZONE1_CURVE): sensor.sensor_schema(
+        cv.Optional(CONF_ZONE1_TARGET_TEMPERATURE): sensor.sensor_schema(
+            unit_of_measurement=UNIT_CELSIUS,
             accuracy_decimals=0,
+            device_class=DEVICE_CLASS_TEMPERATURE,
             state_class=STATE_CLASS_MEASUREMENT,
         ),
         cv.Optional(CONF_FAILED_CRCS): sensor.sensor_schema(
@@ -411,9 +413,9 @@ async def to_code(config):
     if CONF_ZONE1_WATER_TEMPERATURE in config:
         sens = await sensor.new_sensor(config[CONF_ZONE1_WATER_TEMPERATURE])
         cg.add(var.set_zone1_water_temp_sensor(sens))
-    if CONF_ZONE1_CURVE in config:
-        sens = await sensor.new_sensor(config[CONF_ZONE1_CURVE])
-        cg.add(var.set_zone1_curve_sensor(sens))
+    if CONF_ZONE1_TARGET_TEMPERATURE in config:
+        sens = await sensor.new_sensor(config[CONF_ZONE1_TARGET_TEMPERATURE])
+        cg.add(var.set_zone1_target_temperature_sensor(sens))
     if CONF_OUTDOOR_TEMPERATURE in config:
         sens = await sensor.new_sensor(config[CONF_OUTDOOR_TEMPERATURE])
         cg.add(var.set_outdoor_temp_sensor(sens))

--- a/components/toshiba_ab/toshiba_ab.cpp
+++ b/components/toshiba_ab/toshiba_ab.cpp
@@ -3195,7 +3195,7 @@ void ToshibaAbClimate::process_received_data_estia_first_gen_(const DataFrame *f
     this->publish_state();
     if (this->zone1_switch_) this->zone1_switch_->publish_state(this->estia_first_gen_zone1_active_);
     if (this->dhw_boost_switch_) this->dhw_boost_switch_->publish_state(this->estia_first_gen_dhw_boost_);
-    if (this->zone1_curve_sensor_) this->zone1_curve_sensor_->publish_state(static_cast<float>(frame->raw[10]) / 2.0f - 16.0f);
+    if (this->zone1_target_temperature_sensor_) this->zone1_target_temperature_sensor_->publish_state(static_cast<float>(frame->raw[10]) / 2.0f - 16.0f);
     if (len > 18 && this->zone1_water_temp_sensor_) this->zone1_water_temp_sensor_->publish_state(static_cast<float>(frame->raw[14]) / 2.0f - 16.0f);
     this->estia_first_gen_pump_state_known_ = true;
   } else if (src == this->master_address_ && frame->raw[4] == 0x80 && frame->raw[5] == 0x5C && len > 8) {

--- a/components/toshiba_ab/toshiba_ab.h
+++ b/components/toshiba_ab/toshiba_ab.h
@@ -848,7 +848,7 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
   void set_backup_heater_hours_sensor(sensor::Sensor *sensor) { backup_heater_hours_sensor_ = sensor; }
   void set_demand_sensor(sensor::Sensor *sensor) { demand_sensor_ = sensor; }
   void set_zone1_water_temp_sensor(sensor::Sensor *sensor) { zone1_water_temp_sensor_ = sensor; }
-  void set_zone1_curve_sensor(sensor::Sensor *sensor) { zone1_curve_sensor_ = sensor; }
+  void set_zone1_target_temperature_sensor(sensor::Sensor *sensor) { zone1_target_temperature_sensor_ = sensor; }
   void set_frame_format(FrameFormat format) {
     data_reader.set_frame_format(format);
     frame_format_auto_ = false;
@@ -1005,7 +1005,7 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
   sensor::Sensor *backup_heater_hours_sensor_{nullptr};
   sensor::Sensor *demand_sensor_{nullptr};  // 0-10V interface demand (0..15)
   sensor::Sensor *zone1_water_temp_sensor_{nullptr};
-  sensor::Sensor *zone1_curve_sensor_{nullptr};
+  sensor::Sensor *zone1_target_temperature_sensor_{nullptr};
 
   // rx handler for 0x1A (sensor) replies (called from process_received_data)
   void process_sensor_value_(const DataFrame *frame);


### PR DESCRIPTION
### Motivation
- The Estia sensor previously exposed as `zone1_curve` actually represents the Zone 1 target temperature, so the configuration key and internal names were misleading and lacked proper temperature metadata.

### Description
- Rename configuration constant from `CONF_ZONE1_CURVE` to `CONF_ZONE1_TARGET_TEMPERATURE` and update the config schema key to `"zone1_target_temperature"` in `components/toshiba_ab/climate.py`.
- Mark the sensor as a Celsius temperature measurement by adding `unit_of_measurement=UNIT_CELSIUS` and `device_class=DEVICE_CLASS_TEMPERATURE` in the sensor schema.
- Update code generation to call `set_zone1_target_temperature_sensor(...)` instead of the old curve setter in `components/toshiba_ab/climate.py`.
- Rename the C++ setter and member from `set_zone1_curve_sensor`/`zone1_curve_sensor_` to `set_zone1_target_temperature_sensor`/`zone1_target_temperature_sensor_` in `components/toshiba_ab/toshiba_ab.h` and update the publish call in `components/toshiba_ab/toshiba_ab.cpp` to publish to the renamed sensor.

### Testing
- Ran `python -m py_compile components/toshiba_ab/climate.py` and it completed successfully.
- Ran `git diff --check` with no reported whitespace/error issues.
- Searched the tree with `rg -n "zone1_curve|set_zone1_curve|curve_sensor" .` to verify old identifiers were removed and replaced, and found only the new `zone1_target_temperature` identifiers where expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e4b7aadd0832fb8458ac49ff305e8)