### PR TITLE
Respect UART parity in hardware UART RX mode

### DIFF
--- a/components/toshiba_ab/climate.py
+++ b/components/toshiba_ab/climate.py
@@ -135,6 +135,14 @@ REPORT_SENSOR_TEMP_SCHEMA = cv.Schema({
 
 
 CONF_HARDWARE_UART_RX_PIN = "hardware_uart_rx_pin"
+CONF_HARDWARE_UART_PARITY = "hardware_uart_parity"
+CONF_PARITY = "parity"
+
+HARDWARE_UART_PARITY = {
+    "NONE": 0,
+    "EVEN": 1,
+    "ODD": 2,
+}
 
 
 def _hardware_uart_rx_pin(value):
@@ -294,6 +302,13 @@ def _pin_number(config):
     return config.get(CONF_NUMBER)
 
 
+def _uart_hub_config(config, callback):
+    cv.Schema(
+        {cv.Required(CONF_UART_ID): fv.id_declaration_match_schema(callback)},
+        extra=cv.ALLOW_EXTRA,
+    )(config)
+
+
 def _auto_hardware_uart_rx_pin(config):
     # On ESP8266, a bus wired as TX=software pin + RX=GPIO13 makes ESPHome use
     # software serial for both directions. Remove RX from the ESPHome UART hub so
@@ -315,11 +330,20 @@ def _auto_hardware_uart_rx_pin(config):
             hub_config.pop(CONF_RX_PIN, None)
         return hub_config
 
-    cv.Schema(
-        {cv.Required(CONF_UART_ID): fv.id_declaration_match_schema(detect_hub)},
-        extra=cv.ALLOW_EXTRA,
-    )(config)
+    _uart_hub_config(config, detect_hub)
     return auto_pin
+
+
+def _hardware_uart_parity(config):
+    parity = None
+
+    def detect_hub(hub_config):
+        nonlocal parity
+        parity = hub_config.get(CONF_PARITY, "NONE")
+        return hub_config
+
+    _uart_hub_config(config, detect_hub)
+    return HARDWARE_UART_PARITY[str(parity).upper()]
 
 
 def validate_uart(config):
@@ -333,6 +357,8 @@ def validate_uart(config):
     )(config)
     if auto_rx_pin is not None:
         config[CONF_HARDWARE_UART_RX_PIN] = auto_rx_pin
+    if CONF_HARDWARE_UART_RX_PIN in config:
+        config[CONF_HARDWARE_UART_PARITY] = _hardware_uart_parity(config)
     return config
 
 
@@ -370,6 +396,8 @@ async def to_code(config):
         cg.add(var.set_autoreset_errors(config[CONF_AUTORESET_ERRORS]))
     if CONF_HARDWARE_UART_RX_PIN in config:
         cg.add(var.set_hardware_uart_rx_pin(config[CONF_HARDWARE_UART_RX_PIN]))
+    if CONF_HARDWARE_UART_PARITY in config:
+        cg.add(var.set_hardware_uart_parity(config[CONF_HARDWARE_UART_PARITY]))
 
     if CONF_CONNECTED in config:
         sens = await binary_sensor.new_binary_sensor(config[CONF_CONNECTED])

--- a/components/toshiba_ab/toshiba_ab.cpp
+++ b/components/toshiba_ab/toshiba_ab.cpp
@@ -1221,12 +1221,19 @@ void ToshibaAbClimate::setup() {
 #ifdef USE_ESP8266
   if (this->hw_uart_rx_enabled_) {
     s_bus_serial.setRxBufferSize(512);
-    s_bus_serial.begin(2400, SERIAL_8E1);
+    uint32_t hw_uart_config = SERIAL_8N1;
+    if (this->hw_uart_parity_ == 1) {
+      hw_uart_config = SERIAL_8E1;
+    } else if (this->hw_uart_parity_ == 2) {
+      hw_uart_config = SERIAL_8O1;
+    }
+    s_bus_serial.begin(2400, hw_uart_config);
     if (this->hw_uart_rx_pin_ == 13) {
       s_bus_serial.swap();  // UART0: RX GPIO3->GPIO13, TX GPIO1->GPIO15 (unused)
     }
-    ESP_LOGCONFIG(TAG, "Hardware UART0 RX enabled on GPIO%u%s", this->hw_uart_rx_pin_,
-                  this->hw_uart_rx_pin_ == 13 ? " (UART0 swapped RX)" : "");
+    ESP_LOGCONFIG(TAG, "Hardware UART0 RX enabled on GPIO%u%s (%s parity)", this->hw_uart_rx_pin_,
+                  this->hw_uart_rx_pin_ == 13 ? " (UART0 swapped RX)" : "",
+                  this->hw_uart_parity_ == 1 ? "even" : (this->hw_uart_parity_ == 2 ? "odd" : "no"));
   }
 #endif
 

--- a/components/toshiba_ab/toshiba_ab.h
+++ b/components/toshiba_ab/toshiba_ab.h
@@ -861,6 +861,7 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
     this->hw_uart_rx_pin_ = pin;
     this->hw_uart_rx_enabled_ = true;
   }
+  void set_hardware_uart_parity(uint8_t parity) { this->hw_uart_parity_ = parity; }
 
   climate::ClimateTraits traits() override;
   void control(const climate::ClimateCall &call) override;
@@ -940,6 +941,9 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
   // unless final validation detects the ESP8266 GPIO13 RX/software-TX case.
   bool hw_uart_rx_enabled_{false};
   uint8_t hw_uart_rx_pin_{0};
+  // 0 = none, 1 = even, 2 = odd. Mirrors the ESPHome UART hub parity setting
+  // so hardware-UART RX mode does not force the bus to 8E1.
+  uint8_t hw_uart_parity_{0};
 
   DataFrameReader data_reader;
   TccState tcc_state;


### PR DESCRIPTION
### Motivation
- The ESP8266 hardware-UART RX swap path always initialized UART0 as `8E1`, which ignored the configured `uart.parity` in YAML and forced the bus to 8E1 when hardware RX was enabled. 
- The component should honor the UART hub parity so received bytes match the host UART configuration when RX is moved to hardware UART0.

### Description
- Added capture of the linked UART hub `parity` during final validation and exposed it as `CONF_HARDWARE_UART_PARITY` so the component knows the configured parity at codegen time. 
- Introduced `hw_uart_parity_` storage and a `set_hardware_uart_parity` setter in the C++ header so the parity can be passed from Python codegen to runtime. 
- Changed ESP8266 UART0 initialization to choose `SERIAL_8N1`, `SERIAL_8E1`, or `SERIAL_8O1` based on the captured parity instead of hard-coding `SERIAL_8E1`, and updated the hardware-UART log message to report the parity used. 
- Kept the existing auto-detect/swapping behavior for GPIO13 while ensuring resulting UART configuration mirrors the YAML parity setting. 

### Testing
- Ran `python -m py_compile components/toshiba_ab/climate.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a41b6b0e160832f9e1ff7bd45073d38)