### PR TITLE
Fix ESP8266 hardware UART config type

### DIFF
--- a/components/toshiba_ab/toshiba_ab.cpp
+++ b/components/toshiba_ab/toshiba_ab.cpp
@@ -1259,7 +1259,7 @@ void ToshibaAbClimate::setup() {
 #ifdef USE_ESP8266
   if (this->hw_uart_rx_enabled_) {
     s_bus_serial.setRxBufferSize(512);
-    uint32_t hw_uart_config = SERIAL_8N1;
+    SerialConfig hw_uart_config = SERIAL_8N1;
     if (this->hw_uart_parity_ == 1) {
       hw_uart_config = SERIAL_8E1;
     } else if (this->hw_uart_parity_ == 2) {


### PR DESCRIPTION
### Motivation
- Fix a compilation error caused by passing a `uint32_t` value to `HardwareSerial::begin` which expects an `SerialConfig` on ESP8266.

### Description
- Change the `hw_uart_config` variable from `uint32_t` to `SerialConfig` and keep existing parity selection so the value passed to `s_bus_serial.begin(2400, hw_uart_config)` has the correct type.

### Testing
- Ran `git diff --check` to validate the change and ensure no whitespace/issues were introduced and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a434265927c832fb890f3d0223b2aa0)