### PR TITLE
Fix Estia first-gen frame length handling

### DIFF
--- a/components/toshiba_ab/toshiba_ab.cpp
+++ b/components/toshiba_ab/toshiba_ab.cpp
@@ -3184,7 +3184,9 @@ static DataFrame make_estia_first_gen_frame(uint8_t src, uint8_t dst, const uint
   frame.raw[2] = dst;
   for (size_t i = 0; i < payload_len; i++) frame.raw[3 + i] = payload[i];
   frame.raw[inner_size - 1] = estia_first_gen_raw_checksum(frame.raw, inner_size);
-  frame.data_length = inner_size >= 5 ? inner_size - 5 : 0;
+  // Do not assign frame.data_length here: it aliases raw[3], which is the
+  // first-generation Estia payload marker (typically 0xE0). DataFrame::size()
+  // derives TU2C/first-generation Estia length from raw[0].
   frame.set_tu2c(true);
   return frame;
 }

--- a/components/toshiba_ab/toshiba_ab.h
+++ b/components/toshiba_ab/toshiba_ab.h
@@ -150,6 +150,17 @@ struct DataFrame {
    * Returns 0 if not present.
    */
   size_t size() const {
+    if (tu2c_) {
+      // TU2C/first-generation Estia frames store their wrapped length in raw[0].
+      // raw[3] is a protocol byte (for first-generation Estia this is commonly
+      // 0xE0), so do not use the data_length union member because it aliases
+      // raw[3] and would corrupt the frame.
+      if (raw[0] <= 3 || raw[0] > DATA_FRAME_MAX_SIZE + 3)
+        return 0;
+
+      return raw[0] - 3;
+    }
+
     if (!validate_bounds())
       return 0;
 
@@ -478,11 +489,9 @@ struct DataFrameReader {
           reset();
           return false;
         }
-        if (data_index_ >= DATA_OFFSET_FROM_START + 1) {
-          frame.data_length = data_index_ - DATA_OFFSET_FROM_START - 1;  // subtract CRC
-        } else {
-          frame.data_length = 0;
-        }
+        // Do not assign frame.data_length for TU2C/first-generation Estia frames:
+        // data_length is unioned with raw[3], which is an on-wire protocol byte.
+        // The frame size is derived from raw[0] by DataFrame::size().
         crc_valid = false;
         complete  = true;
 


### PR DESCRIPTION
### Motivation
- First-generation Estia (TU2C-wrapped) frames include an on-wire protocol byte at `raw[3]` (commonly `0xE0`) that was being overwritten by the code path which used the `data_length` union member; this broke parsing and transmission of Estia first-gen frames. 
- The wrapped/TU2C frames actually carry their total inner length in `raw[0]`, so frame sizing and encoding must use that instead of the aliasing `data_length` field. 

### Description
- Updated `DataFrame::size()` to special-case TU2C/first-gen Estia frames (`tu2c_ == true`) and derive the frame size from `raw[0]` (returns `raw[0] - 3`) with sanity checks, instead of relying on the `data_length` union member. 
- Stopped assigning `frame.data_length` in the TU2C reader when a wrapped frame completes so the on-wire `raw[3]` byte is preserved. 
- Removed the assignment to `frame.data_length` when constructing first-generation Estia command frames (`make_estia_first_gen_frame`) so transmitted frames keep the payload marker at `raw[3]` (e.g. `0xE0`) instead of being clobbered. 
- Added clarifying comments where the logic was changed to document why `data_length` must not be used for TU2C/first-gen Estia frames.

### Testing
- Ran `git diff --check` to validate there are no whitespace or simple diff issues, which completed without errors. 
- Attempted to run a full build with `platformio run`, but `platformio` is not installed in the execution environment so the firmware build was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a434c6e2954832fa319485a90e70d1f)