### PR TITLE
Add DHW current temperature sensor (Estia first-gen, 0x0A)

### DIFF
--- a/components/toshiba_ab/climate.py
+++ b/components/toshiba_ab/climate.py
@@ -66,6 +66,7 @@ CONF_ZONE1_SWITCH = "zone1_switch"
 CONF_DHW_BOOST = "dhw_boost"
 CONF_ZONE1_WATER_TEMPERATURE = "zone1_water_temperature"
 CONF_ZONE1_TARGET_TEMPERATURE = "zone1_target_temperature"
+CONF_DHW_CURRENT_TEMPERATURE = "dhw_current_temperature"
 
 #AC Sensors addresses
 
@@ -238,6 +239,12 @@ CONFIG_SCHEMA = climate._CLIMATE_SCHEMA.extend(
             state_class=STATE_CLASS_MEASUREMENT,
         ),
         cv.Optional(CONF_ZONE1_TARGET_TEMPERATURE): sensor.sensor_schema(
+            unit_of_measurement=UNIT_CELSIUS,
+            accuracy_decimals=0,
+            device_class=DEVICE_CLASS_TEMPERATURE,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        cv.Optional(CONF_DHW_CURRENT_TEMPERATURE): sensor.sensor_schema(
             unit_of_measurement=UNIT_CELSIUS,
             accuracy_decimals=0,
             device_class=DEVICE_CLASS_TEMPERATURE,
@@ -444,6 +451,12 @@ async def to_code(config):
     if CONF_ZONE1_TARGET_TEMPERATURE in config:
         sens = await sensor.new_sensor(config[CONF_ZONE1_TARGET_TEMPERATURE])
         cg.add(var.set_zone1_target_temperature_sensor(sens))
+
+    has_dhw_current_sensor = CONF_DHW_CURRENT_TEMPERATURE in config
+    if has_dhw_current_sensor:
+        dhw_current_sens = await sensor.new_sensor(config[CONF_DHW_CURRENT_TEMPERATURE])
+        cg.add(var.set_dhw_current_temp_sensor(dhw_current_sens))
+        cg.add(var.add_polled_sensor(0x0A, 1.0, cg.uint32(120000), dhw_current_sens))
     if CONF_OUTDOOR_TEMPERATURE in config:
         sens = await sensor.new_sensor(config[CONF_OUTDOOR_TEMPERATURE])
         cg.add(var.set_outdoor_temp_sensor(sens))
@@ -462,12 +475,21 @@ async def to_code(config):
         sens = await sensor.new_sensor(config[CONF_DEMAND])
         cg.add(var.set_demand_sensor(sens))
     
+    has_dhw_current_poll = has_dhw_current_sensor
     for item in config.get(CONF_SENSORS, []):
+        if item[CONF_ADDRESS] == 0x0A and has_dhw_current_sensor:
+            continue
         sens = await sensor.new_sensor(item["sensor"])  # creates the Sensor with name/units/etc.
         addr = item[CONF_ADDRESS]
         scale = item[CONF_SCALE]
         interval_ms = item[CONF_INTERVAL]
         cg.add(var.add_polled_sensor(addr, scale, cg.uint32(interval_ms), sens))
+        if addr == 0x0A:
+            cg.add(var.set_dhw_current_temp_sensor(sens))
+            has_dhw_current_poll = True
+
+    if not has_dhw_current_poll:
+        cg.add(var.add_polled_sensor(0x0A, 1.0, cg.uint32(120000), cg.nullptr))
 
     # Periodically report a local ESPHome temperature sensor to the AC as "remote temp"
     if (rst := config.get(CONF_REPORT_SENSOR_TEMP)) is not None:

--- a/components/toshiba_ab/toshiba_ab.cpp
+++ b/components/toshiba_ab/toshiba_ab.cpp
@@ -950,9 +950,13 @@ void ToshibaAbClimate::process_sensor_value_(const DataFrame *frame) {
 
     if (prev_id != 0xFF) {
       for (auto &ps : this->polled_sensors_) {
-        if (ps.id == prev_id && ps.sensor != nullptr) {
+        if (ps.id == prev_id) {
           const float value = static_cast<float>(raw) * ps.scale;
-          ps.sensor->publish_state(value);
+          if (prev_id == ESTIA_FIRST_GEN_DHW_TEMP_REQUEST) {
+            this->publish_dhw_current_temperature_(value);
+          } else if (ps.sensor != nullptr) {
+            ps.sensor->publish_state(value);
+          }
           ESP_LOGD(TAG, "0x1A short: id=0x%02X raw=0x%04X -> %.3f", prev_id, raw, value);
           break;
         }
@@ -979,9 +983,13 @@ void ToshibaAbClimate::process_sensor_value_(const DataFrame *frame) {
     const uint16_t raw = (static_cast<uint16_t>(frame->data[7]) << 8) | frame->data[8];
 
     for (auto &ps : this->polled_sensors_) {
-      if (ps.id == id && ps.sensor != nullptr) {
+      if (ps.id == id) {
         const float value = static_cast<float>(raw) * ps.scale;
-        ps.sensor->publish_state(value);
+        if (id == ESTIA_FIRST_GEN_DHW_TEMP_REQUEST) {
+          this->publish_dhw_current_temperature_(value);
+        } else if (ps.sensor != nullptr) {
+          ps.sensor->publish_state(value);
+        }
         ESP_LOGD(TAG, "0x1A long:  id=0x%02X raw=0x%04X -> %.3f", id, raw, value);
         break;
       }
@@ -1002,6 +1010,25 @@ void ToshibaAbClimate::process_sensor_value_(const DataFrame *frame) {
   this->last_sensor_query_id_     = 0xFF;
 }
 
+
+void ToshibaAbClimate::publish_dhw_current_temperature_(float temperature) {
+  if (temperature < 0 || temperature > 95) {
+    ESP_LOGW(TAG, "Ignoring DHW current temperature %.1f °C outside expected range", temperature);
+    return;
+  }
+
+  bool changed = false;
+  if (this->current_temperature != temperature) {
+    this->current_temperature = temperature;
+    changed = true;
+  }
+  if (this->dhw_current_temp_sensor_ != nullptr) {
+    this->dhw_current_temp_sensor_->publish_state(temperature);
+  }
+  if (changed) {
+    this->publish_state();
+  }
+}
 
 uint8_t to_tcc_power(const climate::ClimateMode mode) {
   switch (mode) {
@@ -2502,14 +2529,6 @@ void ToshibaAbClimate::loop() {
     }
   }
 
-  // First-generation Estia status normally carries DHW cylinder temperature.
-  // If this master omits it, poll only that thermostat-critical value.
-  if (this->data_reader.frame_format() == FrameFormat::ESTIA && !this->estia_first_gen_status_reports_dhw_temp_ &&
-      !this->sensor_query_outstanding_ && (now - this->estia_first_gen_last_dhw_poll_ms_) >= ESTIA_FIRST_GEN_DHW_POLL_INTERVAL_MS) {
-    this->estia_first_gen_last_dhw_poll_ms_ = now;
-    this->send_sensor_query(ESTIA_FIRST_GEN_DHW_TEMP_REQUEST);
-  }
-
   // Estia autonomous polling (runtime-toggleable)
   if (this->autonomous_ && this->data_reader.frame_format() == FrameFormat::A0) {
     uint32_t now = millis();
@@ -3298,8 +3317,6 @@ void ToshibaAbClimate::process_received_data_estia_first_gen_(const DataFrame *f
     this->estia_first_gen_zone1_encoded_ = frame->raw[10];
     this->mode = this->estia_first_gen_dhw_active_ ? climate::CLIMATE_MODE_HEAT : climate::CLIMATE_MODE_OFF;
     this->target_temperature = static_cast<float>(frame->raw[9]) / 2.0f - 16.0f;
-    this->current_temperature = this->target_temperature;
-    this->estia_first_gen_status_reports_dhw_temp_ = true;
     this->publish_state();
     if (this->zone1_switch_) this->zone1_switch_->publish_state(this->estia_first_gen_zone1_active_);
     if (this->dhw_boost_switch_) this->dhw_boost_switch_->publish_state(this->estia_first_gen_dhw_boost_);
@@ -3310,14 +3327,13 @@ void ToshibaAbClimate::process_received_data_estia_first_gen_(const DataFrame *f
     const uint16_t value = encode_uint16(frame->raw[6], frame->raw[7]);
     bool published_polled_sensor = false;
     if (this->last_sensor_query_id_ != 0xFF) {
-      if (this->last_sensor_query_id_ == ESTIA_FIRST_GEN_DHW_TEMP_REQUEST &&
-          !this->estia_first_gen_status_reports_dhw_temp_) {
-        this->current_temperature = static_cast<float>(value);
-        this->publish_state();
-      }
       for (auto &ps : this->polled_sensors_) {
-        if (ps.id == this->last_sensor_query_id_ && ps.sensor != nullptr) {
-          ps.sensor->publish_state(static_cast<float>(value) * ps.scale);
+        if (ps.id == this->last_sensor_query_id_) {
+          if (this->last_sensor_query_id_ == ESTIA_FIRST_GEN_DHW_TEMP_REQUEST) {
+            this->publish_dhw_current_temperature_(static_cast<float>(value) * ps.scale);
+          } else if (ps.sensor != nullptr) {
+            ps.sensor->publish_state(static_cast<float>(value) * ps.scale);
+          }
           published_polled_sensor = true;
           ESP_LOGD(TAG, "Estia first-gen sensor: id=0x%02X raw=0x%04X", this->last_sensor_query_id_, value);
           break;

--- a/components/toshiba_ab/toshiba_ab.h
+++ b/components/toshiba_ab/toshiba_ab.h
@@ -844,6 +844,7 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
   void set_demand_sensor(sensor::Sensor *sensor) { demand_sensor_ = sensor; }
   void set_zone1_water_temp_sensor(sensor::Sensor *sensor) { zone1_water_temp_sensor_ = sensor; }
   void set_zone1_target_temperature_sensor(sensor::Sensor *sensor) { zone1_target_temperature_sensor_ = sensor; }
+  void set_dhw_current_temp_sensor(sensor::Sensor *sensor) { dhw_current_temp_sensor_ = sensor; }
   void set_frame_format(FrameFormat format) {
     data_reader.set_frame_format(format);
     frame_format_auto_ = false;
@@ -1005,9 +1006,11 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
   sensor::Sensor *demand_sensor_{nullptr};  // 0-10V interface demand (0..15)
   sensor::Sensor *zone1_water_temp_sensor_{nullptr};
   sensor::Sensor *zone1_target_temperature_sensor_{nullptr};
+  sensor::Sensor *dhw_current_temp_sensor_{nullptr};
 
   // rx handler for 0x1A (sensor) replies (called from process_received_data)
   void process_sensor_value_(const DataFrame *frame);
+  void publish_dhw_current_temperature_(float temperature);
   std::vector<PolledSensor> polled_sensors_;
 
 
@@ -1128,10 +1131,7 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
   bool estia_first_gen_dhw_boost_{false};
   uint8_t estia_first_gen_dhw_encoded_{0};
   uint8_t estia_first_gen_zone1_encoded_{0};
-  bool estia_first_gen_status_reports_dhw_temp_{false};
-  uint32_t estia_first_gen_last_dhw_poll_ms_{0};
-  static const uint32_t ESTIA_FIRST_GEN_DHW_POLL_INTERVAL_MS = 60000;
-  static const uint8_t ESTIA_FIRST_GEN_DHW_TEMP_REQUEST = 0x08;
+  static const uint8_t ESTIA_FIRST_GEN_DHW_TEMP_REQUEST = 0x0A;
   uint32_t last_temp_log_time_ = 0;  // Counter for BME280 temperature logging
   float last_sent_temp_ = 1; // Last sent room temperature to the unit
 


### PR DESCRIPTION
### Motivation

- Expose and consistently handle the DHW (cylinder) current temperature reported by first-generation Estia units which is polled at address `0x0A`.
- Prevent duplicate polling and ensure the DHW temperature is published both to a dedicated sensor and as the climate current temperature.

### Description

- Add `CONF_DHW_CURRENT_TEMPERATURE` to `components/toshiba_ab/climate.py` and include it in the configuration schema so a dedicated DHW current temperature sensor can be created and polled.
- Wire the new sensor into `to_code` so it is created, registered with `set_dhw_current_temp_sensor`, and polled at address `0x0A`; avoid duplicate polls if the same address is provided via `CONF_SENSORS`, and add a default poll for `0x0A` (with `nullptr`) when no sensor is configured.
- Add `dhw_current_temp_sensor_` member and `set_dhw_current_temp_sensor` setter to the C++ header, introduce `publish_dhw_current_temperature_` to update the climate `current_temperature`, publish the sensor state, and only call `publish_state()` when the climate-state changed.
- Route both short and long 0x1A sensor replies to call `publish_dhw_current_temperature_` when the sensor ID equals `ESTIA_FIRST_GEN_DHW_TEMP_REQUEST`, change `ESTIA_FIRST_GEN_DHW_TEMP_REQUEST` from `0x08` to `0x0A`, and remove the previous ad-hoc polling fallback for first-gen Estia.

### Testing

- Compiled the firmware (C++ build) to validate the changes to `components/toshiba_ab` and the added symbols using the normal ESPHome/PlatformIO build process, and the build completed successfully.
- No additional automated unit tests were added for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4398324ff4832faa8036dbceb4ddea)