### PR TITLE
Estia: add first-gen auto mode command and hotwater heating binary sensors

### DIFF
--- a/components/toshiba_ab/climate.py
+++ b/components/toshiba_ab/climate.py
@@ -67,6 +67,8 @@ CONF_DHW_BOOST = "dhw_boost"
 CONF_ZONE1_WATER_TEMPERATURE = "zone1_water_temperature"
 CONF_ZONE1_TARGET_TEMPERATURE = "zone1_target_temperature"
 CONF_DHW_CURRENT_TEMPERATURE = "dhw_current_temperature"
+CONF_HOTWATER_PUMP_HEATING = "hotwater_pump_heating"
+CONF_HOTWATER_RESISTOR_HEATING = "hotwater_resistor_heating"
 
 #AC Sensors addresses
 
@@ -250,6 +252,8 @@ CONFIG_SCHEMA = climate._CLIMATE_SCHEMA.extend(
             device_class=DEVICE_CLASS_TEMPERATURE,
             state_class=STATE_CLASS_MEASUREMENT,
         ),
+        cv.Optional(CONF_HOTWATER_PUMP_HEATING): binary_sensor.binary_sensor_schema(),
+        cv.Optional(CONF_HOTWATER_RESISTOR_HEATING): binary_sensor.binary_sensor_schema(),
         cv.Optional(CONF_FAILED_CRCS): sensor.sensor_schema(
             accuracy_decimals=0,
             entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
@@ -457,6 +461,12 @@ async def to_code(config):
         dhw_current_sens = await sensor.new_sensor(config[CONF_DHW_CURRENT_TEMPERATURE])
         cg.add(var.set_dhw_current_temp_sensor(dhw_current_sens))
         cg.add(var.add_polled_sensor(0x0A, 1.0, cg.uint32(120000), dhw_current_sens))
+    if CONF_HOTWATER_PUMP_HEATING in config:
+        sens = await binary_sensor.new_binary_sensor(config[CONF_HOTWATER_PUMP_HEATING])
+        cg.add(var.set_hotwater_pump_heating_binary_sensor(sens))
+    if CONF_HOTWATER_RESISTOR_HEATING in config:
+        sens = await binary_sensor.new_binary_sensor(config[CONF_HOTWATER_RESISTOR_HEATING])
+        cg.add(var.set_hotwater_resistor_heating_binary_sensor(sens))
     if CONF_OUTDOOR_TEMPERATURE in config:
         sens = await sensor.new_sensor(config[CONF_OUTDOOR_TEMPERATURE])
         cg.add(var.set_outdoor_temp_sensor(sens))

--- a/components/toshiba_ab/toshiba_ab.cpp
+++ b/components/toshiba_ab/toshiba_ab.cpp
@@ -2761,11 +2761,7 @@ void ToshibaAbClimate::control(const climate::ClimateCall &call) {
   if (this->data_reader.frame_format() == FrameFormat::ESTIA) {
     if (call.get_mode().has_value()) {
       auto new_mode = call.get_mode().value();
-      if (new_mode == climate::CLIMATE_MODE_OFF) {
-        this->send_estia_first_gen_dhw_boost(false);
-      } else {
-        this->send_estia_first_gen_dhw_boost(true);
-      }
+      this->send_estia_first_gen_auto_mode(new_mode != climate::CLIMATE_MODE_OFF);
     }
     if (call.get_target_temperature().has_value()) {
       this->send_estia_first_gen_dhw_setpoint(call.get_target_temperature().value());
@@ -3222,6 +3218,12 @@ void ToshibaAbClimate::send_estia_first_gen_dhw_boost(bool on) {
   this->send_command(make_estia_first_gen_frame(this->remote_address_, this->master_address_, payload, sizeof(payload)));
 }
 
+void ToshibaAbClimate::send_estia_first_gen_auto_mode(bool on) {
+  if (this->read_only_) return;
+  const uint8_t payload[] = {0xE0, 0x01, 0x24, 0x01, static_cast<uint8_t>(on ? 0x01 : 0x00)};
+  this->send_command(make_estia_first_gen_frame(this->remote_address_, this->master_address_, payload, sizeof(payload)));
+}
+
 void ToshibaAbClimate::send_estia_first_gen_dhw_setpoint(float target_temp) {
   if (this->read_only_) return;
   uint8_t encoded = static_cast<uint8_t>(std::round((target_temp + 16.0f) * 2.0f));
@@ -3313,13 +3315,22 @@ void ToshibaAbClimate::process_received_data_estia_first_gen_(const DataFrame *f
     this->estia_first_gen_zone1_active_ = frame->raw[6] & 0x01;
     this->estia_first_gen_dhw_active_ = frame->raw[6] & 0x02;
     this->estia_first_gen_dhw_boost_ = this->estia_first_gen_dhw_active_;
+    this->estia_first_gen_auto_mode_active_ = frame->raw[7] & 0x04;
+    this->estia_first_gen_hotwater_resistor_heating_ = frame->raw[8] & 0x04;
+    this->estia_first_gen_hotwater_pump_heating_ = frame->raw[8] & 0x08;
     this->estia_first_gen_dhw_encoded_ = frame->raw[9];
     this->estia_first_gen_zone1_encoded_ = frame->raw[10];
-    this->mode = this->estia_first_gen_dhw_active_ ? climate::CLIMATE_MODE_HEAT : climate::CLIMATE_MODE_OFF;
+    this->mode = (this->estia_first_gen_auto_mode_active_ || this->estia_first_gen_dhw_active_)
+                     ? climate::CLIMATE_MODE_HEAT
+                     : climate::CLIMATE_MODE_OFF;
     this->target_temperature = static_cast<float>(frame->raw[9]) / 2.0f - 16.0f;
     this->publish_state();
     if (this->zone1_switch_) this->zone1_switch_->publish_state(this->estia_first_gen_zone1_active_);
     if (this->dhw_boost_switch_) this->dhw_boost_switch_->publish_state(this->estia_first_gen_dhw_boost_);
+    if (this->hotwater_pump_heating_binary_sensor_)
+      this->hotwater_pump_heating_binary_sensor_->publish_state(this->estia_first_gen_hotwater_pump_heating_);
+    if (this->hotwater_resistor_heating_binary_sensor_)
+      this->hotwater_resistor_heating_binary_sensor_->publish_state(this->estia_first_gen_hotwater_resistor_heating_);
     if (this->zone1_target_temperature_sensor_) this->zone1_target_temperature_sensor_->publish_state(static_cast<float>(frame->raw[10]) / 2.0f - 16.0f);
     if (len > 18 && this->zone1_water_temp_sensor_) this->zone1_water_temp_sensor_->publish_state(static_cast<float>(frame->raw[14]) / 2.0f - 16.0f);
     this->estia_first_gen_pump_state_known_ = true;

--- a/components/toshiba_ab/toshiba_ab.h
+++ b/components/toshiba_ab/toshiba_ab.h
@@ -845,6 +845,8 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
   void set_zone1_water_temp_sensor(sensor::Sensor *sensor) { zone1_water_temp_sensor_ = sensor; }
   void set_zone1_target_temperature_sensor(sensor::Sensor *sensor) { zone1_target_temperature_sensor_ = sensor; }
   void set_dhw_current_temp_sensor(sensor::Sensor *sensor) { dhw_current_temp_sensor_ = sensor; }
+  void set_hotwater_pump_heating_binary_sensor(binary_sensor::BinarySensor *sensor) { hotwater_pump_heating_binary_sensor_ = sensor; }
+  void set_hotwater_resistor_heating_binary_sensor(binary_sensor::BinarySensor *sensor) { hotwater_resistor_heating_binary_sensor_ = sensor; }
   void set_frame_format(FrameFormat format) {
     data_reader.set_frame_format(format);
     frame_format_auto_ = false;
@@ -915,6 +917,7 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
   void send_estia_first_gen_dhw_setpoint(float target_temp);
   void send_estia_first_gen_zone1(bool on);
   void send_estia_first_gen_dhw_boost(bool on);
+  void send_estia_first_gen_auto_mode(bool on);
   void send_estia_first_gen_request_data(uint8_t request_code);
   void send_estia_tracked_(const uint8_t *frame, size_t len, uint16_t ack_dtype);
   
@@ -1007,6 +1010,8 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
   sensor::Sensor *zone1_water_temp_sensor_{nullptr};
   sensor::Sensor *zone1_target_temperature_sensor_{nullptr};
   sensor::Sensor *dhw_current_temp_sensor_{nullptr};
+  binary_sensor::BinarySensor *hotwater_pump_heating_binary_sensor_{nullptr};
+  binary_sensor::BinarySensor *hotwater_resistor_heating_binary_sensor_{nullptr};
 
   // rx handler for 0x1A (sensor) replies (called from process_received_data)
   void process_sensor_value_(const DataFrame *frame);
@@ -1129,6 +1134,9 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
   bool estia_first_gen_zone1_active_{false};
   bool estia_first_gen_dhw_active_{false};
   bool estia_first_gen_dhw_boost_{false};
+  bool estia_first_gen_auto_mode_active_{false};
+  bool estia_first_gen_hotwater_pump_heating_{false};
+  bool estia_first_gen_hotwater_resistor_heating_{false};
   uint8_t estia_first_gen_dhw_encoded_{0};
   uint8_t estia_first_gen_zone1_encoded_{0};
   static const uint8_t ESTIA_FIRST_GEN_DHW_TEMP_REQUEST = 0x0A;


### PR DESCRIPTION
### Motivation
- Expose Estia first-generation "auto" mode state and hotwater heating indicators to configuration and runtime so automations can observe pump/resistor heating and auto-mode status.
- Provide a command to toggle Estia first-gen auto mode from climate controls instead of reusing the DHW boost command.

### Description
- Added two new configuration keys `CONF_HOTWATER_PUMP_HEATING` and `CONF_HOTWATER_RESISTOR_HEATING` and exposed them in the component `CONFIG_SCHEMA` as binary sensors.
- Wire the new binary sensors in the Python code by calling `set_hotwater_pump_heating_binary_sensor(...)` and `set_hotwater_resistor_heating_binary_sensor(...)` during `to_code` generation.
- Added `send_estia_first_gen_auto_mode(bool)` method to the C++ component and declared it in the header so the climate call can toggle first-gen Estia auto mode explicitly.
- Parse additional bits from Estia first-gen status frames to set `estia_first_gen_auto_mode_active_`, `estia_first_gen_hotwater_pump_heating_` and `estia_first_gen_hotwater_resistor_heating_` flags.
- Updated mode determination to consider auto mode active as `CLIMATE_MODE_HEAT`, and publish the new binary sensor states when available.
- Updated `control()` to call `send_estia_first_gen_auto_mode(...)` based on the requested mode for first-gen Estia frames.

### Testing
- Built the firmware for the modified component with the ESPHome/PlatformIO toolchain (`esphome compile`/`pio run`) and the build completed successfully.
- No additional automated unit tests exist for this component; existing compilation verifies the new symbols and schema integration succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43a5079128832f81d1610348a4a8a7)