### PR TITLE
Filter ESTIA TU2C TX echo frames and default ESTIA master address

### DIFF
--- a/components/toshiba_ab/toshiba_ab.cpp
+++ b/components/toshiba_ab/toshiba_ab.cpp
@@ -141,8 +141,19 @@ bool ToshibaAbClimate::is_own_tx_echo_(const DataFrame *f) const { // used to fi
   if (!this->last_tx_frame_for_echo_.has_value() || f == nullptr) return false;
   if ((millis() - this->last_tx_frame_millis_) > ECHO_MATCH_WINDOW_MS) return false;
   const auto &tx = this->last_tx_frame_for_echo_.value();  // last frame we wrote
-  if (f->size() != tx.size()) return false;
-  return std::memcmp(f->raw, tx.raw, f->size()) == 0;
+  if (f->size() == tx.size() && std::memcmp(f->raw, tx.raw, f->size()) == 0) return true;
+
+  // First-generation Estia uses the TU2C reader path. On some adapters the
+  // local TX can be echoed back with slightly different wrapper/timing state,
+  // so fall back to dropping recent frames that still have our Estia source,
+  // current master destination and known local command/query markers.
+  if (this->data_reader.frame_format() == FrameFormat::ESTIA && f->is_tu2c() && f->size() >= 6 &&
+      f->raw[1] == this->remote_address_ && f->raw[2] == this->master_address_ &&
+      f->raw[3] == 0xE0 && (f->raw[4] == 0x01 || f->raw[4] == 0x41)) {
+    return true;
+  }
+
+  return false;
 }
 
 void ToshibaAbClimate::remember_tx_frame_for_echo_(const uint8_t *bytes, size_t size, bool tu2c) {

--- a/components/toshiba_ab/toshiba_ab.h
+++ b/components/toshiba_ab/toshiba_ab.h
@@ -853,6 +853,7 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
     frame_format_confirmed_ = true;
     if (format == FrameFormat::ESTIA) {
       if (remote_address_auto_) remote_address_ = TOSHIBA_ESTIA_REMOTE_DEFAULT;
+      if (master_address_auto_ && master_address_ == 0x00) master_address_ = TOSHIBA_ESTIA_MASTER_DEFAULT;
     }
   }
   void set_frame_format_auto() {


### PR DESCRIPTION
### Motivation
- Avoid misclassifying echoed TX frames from first-generation Estia adapters that are wrapped slightly differently on the TU2C reader path. 
- Ensure a sensible default `master_address` is applied when explicitly switching to `FrameFormat::ESTIA` and the master address is still auto/zero.

### Description
- Enhance `ToshibaAbClimate::is_own_tx_echo_` to first check for exact frame equality and then fall back to dropping recent frames that match ESTIA TU2C-specific markers (`FrameFormat::ESTIA`, `is_tu2c()`, source/destination bytes, and specific command/query byte values). 
- Set `master_address_` to `TOSHIBA_ESTIA_MASTER_DEFAULT` in `set_frame_format` when switching to `FrameFormat::ESTIA` if `master_address_auto_` is true and the current `master_address_` is `0x00`.
- Preserve existing behavior for exact TX echo matching and existing payload handling logic.

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4493cda770832f8e5006e30774ce62)