### PR TITLE
Estia first-gen: map HEAT/OFF to DHW on/off and split DHW commands

### DIFF
--- a/components/toshiba_ab/toshiba_ab.cpp
+++ b/components/toshiba_ab/toshiba_ab.cpp
@@ -2761,14 +2761,16 @@ std::vector<DataFrame> ToshibaAbClimate::create_commands(const struct TccState *
 }
 
 void ToshibaAbClimate::control(const climate::ClimateCall &call) {
-  // Estia A0-protocol: power, mode, setpoint control
-  // Only one command at a time on the half-duplex AB-bus.
-  // When powering on with a mode change, send mode first, then power on
-  // after a delay so the WP starts in the correct mode.
+  // First-generation Estia: the climate entity represents domestic hot water.
+  // HEAT/OFF therefore maps to hot-water on/off, not space-heating auto mode.
   if (this->data_reader.frame_format() == FrameFormat::ESTIA) {
     if (call.get_mode().has_value()) {
       auto new_mode = call.get_mode().value();
-      this->send_estia_first_gen_auto_mode(new_mode != climate::CLIMATE_MODE_OFF);
+      if (new_mode == climate::CLIMATE_MODE_HEAT) {
+        this->send_estia_first_gen_dhw_on();
+      } else if (new_mode == climate::CLIMATE_MODE_OFF) {
+        this->send_estia_first_gen_dhw_off();
+      }
     }
     if (call.get_target_temperature().has_value()) {
       this->send_estia_first_gen_dhw_setpoint(call.get_target_temperature().value());
@@ -3219,10 +3221,25 @@ void ToshibaAbClimate::send_estia_first_gen_zone1(bool on) {
   this->send_command(make_estia_first_gen_frame(this->remote_address_, this->master_address_, payload, sizeof(payload)));
 }
 
-void ToshibaAbClimate::send_estia_first_gen_dhw_boost(bool on) {
+void ToshibaAbClimate::send_estia_first_gen_dhw_on() {
   if (this->read_only_) return;
-  const uint8_t payload[] = {0xE0, 0x01, 0x21, static_cast<uint8_t>(on ? 0x0C : 0x08)};
+  const uint8_t payload[] = {0xE0, 0x01, 0x21, 0x0C};
   this->send_command(make_estia_first_gen_frame(this->remote_address_, this->master_address_, payload, sizeof(payload)));
+}
+
+void ToshibaAbClimate::send_estia_first_gen_dhw_off() {
+  if (this->read_only_) return;
+  const uint8_t payload[] = {0xE0, 0x01, 0x21, 0x08};
+  this->send_command(make_estia_first_gen_frame(this->remote_address_, this->master_address_, payload, sizeof(payload)));
+}
+
+void ToshibaAbClimate::send_estia_first_gen_dhw_boost(bool on) {
+  // TODO: Replace this fallback once the first-generation Estia DHW boost command is known.
+  if (on) {
+    this->send_estia_first_gen_dhw_on();
+  } else {
+    this->send_estia_first_gen_dhw_off();
+  }
 }
 
 void ToshibaAbClimate::send_estia_first_gen_auto_mode(bool on) {

--- a/components/toshiba_ab/toshiba_ab.h
+++ b/components/toshiba_ab/toshiba_ab.h
@@ -917,6 +917,8 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
   void send_estia_data_request(uint8_t subtype);
   void send_estia_first_gen_dhw_setpoint(float target_temp);
   void send_estia_first_gen_zone1(bool on);
+  void send_estia_first_gen_dhw_on();
+  void send_estia_first_gen_dhw_off();
   void send_estia_first_gen_dhw_boost(bool on);
   void send_estia_first_gen_auto_mode(bool on);
   void send_estia_first_gen_request_data(uint8_t request_code);


### PR DESCRIPTION
### Motivation

- Clarify and correct behavior for first-generation Estia where the climate entity represents domestic hot water, so HEAT/OFF should toggle DHW rather than space-heating auto mode.

### Description

- Update control flow to map `CLIMATE_MODE_HEAT`/`CLIMATE_MODE_OFF` to new `send_estia_first_gen_dhw_on()` and `send_estia_first_gen_dhw_off()` calls instead of using `send_estia_first_gen_auto_mode()`.
- Introduce `send_estia_first_gen_dhw_on()` and `send_estia_first_gen_dhw_off()` methods sending explicit payloads `0x0C` and `0x08` respectively, and add their declarations to the header.
- Preserve `send_estia_first_gen_dhw_boost(bool)` as a fallback wrapper that delegates to the new on/off methods and add a TODO noting the real boost command is unknown.

### Testing

- Built the firmware successfully using the project build (`platformio run`) with the changes compiled into `components/toshiba_ab`.
- Ran the existing unit/integration test suite and driver checks and they completed without regressions or test failures.
- No new automated tests were added for the first-generation Estia DHW commands in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4707ed7828832fbd858fb2ed71abb8)