### PR TITLE
Recognize master acknowledgement of remote command in Estia frame parsing

### DIFF
--- a/components/toshiba_ab/toshiba_ab.cpp
+++ b/components/toshiba_ab/toshiba_ab.cpp
@@ -3299,6 +3299,9 @@ void ToshibaAbClimate::process_received_data_estia_first_gen_(const DataFrame *f
     if (is_master_source && frame->raw[4] == 0x80 && frame->raw[5] == 0xA2) {
       return "Master reporting data/sensor not available";
     }
+    if (is_master_source && len == 0x0A && frame->raw[4] == 0x80 && frame->raw[5] == 0xA1) {
+      return "Master acknowledging remote command";
+    }
     if (is_master_source && frame->raw[4] == 0x80 && frame->raw[5] == 0x0C) {
       return "Master ackowledging remote PING";
     }


### PR DESCRIPTION
### Motivation
- Add explicit recognition for a master frame that acknowledges a remote command so that logs and diagnostics can report this event clearly.

### Description
- Added a case in `ToshibaAbClimate::process_received_data_estia_first_gen_` that returns "Master acknowledging remote command" when `is_master_source` and `len == 0x0A` with `frame->raw[4] == 0x80` and `frame->raw[5] == 0xA1`.

### Testing
- Built the project and ran the existing automated unit test suite, and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a47249f2e10832f9fc33dea13ba027e)