### PR TITLE
Limit Estia first-gen collision detection to remote pings

### DIFF
--- a/components/toshiba_ab/toshiba_ab.cpp
+++ b/components/toshiba_ab/toshiba_ab.cpp
@@ -3270,6 +3270,7 @@ void ToshibaAbClimate::process_received_data_estia_first_gen_(const DataFrame *f
   const uint8_t src = frame->raw[1];
   const bool has_master_status_signature = frame->raw[3] == 0xE0 && frame->raw[5] == 0x31;
   const bool has_master_keepalive_signature = len == 0x0A && frame->raw[5] == 0x3A;
+  const bool has_remote_ping_signature = frame->raw[3] == 0xE0 && frame->raw[4] == 0x41 && frame->raw[5] == 0x0C;
   const bool is_master_source = src == this->master_address_ ||
                                 (this->master_address_auto_ &&
                                  (has_master_status_signature || has_master_keepalive_signature));
@@ -3313,7 +3314,7 @@ void ToshibaAbClimate::process_received_data_estia_first_gen_(const DataFrame *f
       std::snprintf(buf, sizeof(buf), "remote data/sensor 0x%02X query", frame->raw[6]);
       return buf;
     }
-    if (is_remote_source && frame->raw[3] == 0xE0 && frame->raw[4] == 0x41 && frame->raw[5] == 0x0C) {
+    if (is_remote_source && has_remote_ping_signature) {
       return "Remote PING";
     }
     if (is_remote_source && frame->raw[3] == 0xE0 && frame->raw[4] == 0x01 && frame->raw[5] == 0x21) {
@@ -3338,9 +3339,10 @@ void ToshibaAbClimate::process_received_data_estia_first_gen_(const DataFrame *f
     this->master_address_ = src;
     this->master_address_confirmed_ = true;
   }
-  if (this->remote_address_auto_ && src == this->remote_address_ && this->remote_address_ < TOSHIBA_ESTIA_REMOTE_MAX) {
+  if (this->remote_address_auto_ && src == this->remote_address_ && has_remote_ping_signature &&
+      this->remote_address_ < TOSHIBA_ESTIA_REMOTE_MAX) {
     this->remote_address_++;
-    ESP_LOGI(TAG, "Estia remote-address collision; switching to 0x%02X", this->remote_address_);
+    ESP_LOGI(TAG, "Estia remote-address collision from remote ping; switching to 0x%02X", this->remote_address_);
   }
   if (src == this->master_address_) {
     this->last_master_alive_millis_ = millis();

--- a/docs/estia_first_gen_protocol.md
+++ b/docs/estia_first_gen_protocol.md
@@ -244,7 +244,7 @@ When `master_address_auto_` is enabled:
 1. Component watches for incoming frames
 2. On receipt of a master-status frame (0xE0:0x31), the source address is recorded as the master
 3. Keepalive frames (0xE0:0x3A) with matching keepalive signature confirm master identity
-4. **Remote address auto-detect**: If any frame has `src == remote_address_` and `remote_address_auto_` is true, the next address up to `0x69` is chosen (collision avoidance)
+4. **Remote address auto-detect**: If a received remote ping has `src == remote_address_` and `remote_address_auto_` is true, the next address up to `0x69` is chosen (collision avoidance)
 
 ### Master Alive Timeout
 
@@ -406,7 +406,7 @@ Decoded temperature: 66/2 - 16 = 33 - 16 = 17°C
 
 ### Auto-Detection Collisions
 
-- If received frame source matches current remote address and `remote_address_auto_` is true, increment remote address
+- If a received remote ping source matches current remote address and `remote_address_auto_` is true, increment remote address
 - Report collision in logs
 
 ### Timeouts


### PR DESCRIPTION
### Motivation
- Narrow collision detection for Estia first-generation frames so the component only treats received remote PING frames as a trigger to auto-increment the configured remote address, avoiding false positives from other frame types.

### Description
- Add a `has_remote_ping_signature` check in `process_received_data_estia_first_gen_()` in `components/toshiba_ab/toshiba_ab.cpp` and reuse it to identify remote PING frames and gate the remote-address auto-increment and log message accordingly.
- Update `docs/estia_first_gen_protocol.md` to document that remote address auto-detection/collision handling is triggered only by received remote pings.

### Testing
- Ran `git diff --check` which completed with no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a472841a008832fac4a62eee54be692)