### PR TITLE
Use Estia first-gen status frame for DHW temperature

### DIFF
--- a/components/toshiba_ab/climate.py
+++ b/components/toshiba_ab/climate.py
@@ -456,11 +456,9 @@ async def to_code(config):
         sens = await sensor.new_sensor(config[CONF_ZONE1_TARGET_TEMPERATURE])
         cg.add(var.set_zone1_target_temperature_sensor(sens))
 
-    has_dhw_current_sensor = CONF_DHW_CURRENT_TEMPERATURE in config
-    if has_dhw_current_sensor:
+    if CONF_DHW_CURRENT_TEMPERATURE in config:
         dhw_current_sens = await sensor.new_sensor(config[CONF_DHW_CURRENT_TEMPERATURE])
         cg.add(var.set_dhw_current_temp_sensor(dhw_current_sens))
-        cg.add(var.add_polled_sensor(0x0A, 1.0, cg.uint32(120000), dhw_current_sens))
     if CONF_HOTWATER_PUMP_HEATING in config:
         sens = await binary_sensor.new_binary_sensor(config[CONF_HOTWATER_PUMP_HEATING])
         cg.add(var.set_hotwater_pump_heating_binary_sensor(sens))
@@ -485,21 +483,9 @@ async def to_code(config):
         sens = await sensor.new_sensor(config[CONF_DEMAND])
         cg.add(var.set_demand_sensor(sens))
     
-    has_dhw_current_poll = has_dhw_current_sensor
     for item in config.get(CONF_SENSORS, []):
-        if item[CONF_ADDRESS] == 0x0A and has_dhw_current_sensor:
-            continue
         sens = await sensor.new_sensor(item["sensor"])  # creates the Sensor with name/units/etc.
-        addr = item[CONF_ADDRESS]
-        scale = item[CONF_SCALE]
-        interval_ms = item[CONF_INTERVAL]
-        cg.add(var.add_polled_sensor(addr, scale, cg.uint32(interval_ms), sens))
-        if addr == 0x0A:
-            cg.add(var.set_dhw_current_temp_sensor(sens))
-            has_dhw_current_poll = True
-
-    if not has_dhw_current_poll:
-        cg.add(var.add_polled_sensor(0x0A, 1.0, cg.uint32(120000), cg.nullptr))
+        cg.add(var.add_polled_sensor(item[CONF_ADDRESS], item[CONF_SCALE], cg.uint32(item[CONF_INTERVAL]), sens))
 
     # Periodically report a local ESPHome temperature sensor to the AC as "remote temp"
     if (rst := config.get(CONF_REPORT_SENSOR_TEMP)) is not None:

--- a/components/toshiba_ab/toshiba_ab.cpp
+++ b/components/toshiba_ab/toshiba_ab.cpp
@@ -959,9 +959,7 @@ void ToshibaAbClimate::process_sensor_value_(const DataFrame *frame) {
       for (auto &ps : this->polled_sensors_) {
         if (ps.id == prev_id) {
           const float value = static_cast<float>(raw) * ps.scale;
-          if (prev_id == ESTIA_FIRST_GEN_DHW_TEMP_REQUEST) {
-            this->publish_dhw_current_temperature_(value);
-          } else if (ps.sensor != nullptr) {
+          if (ps.sensor != nullptr) {
             ps.sensor->publish_state(value);
           }
           ESP_LOGD(TAG, "0x1A short: id=0x%02X raw=0x%04X -> %.3f", prev_id, raw, value);
@@ -992,9 +990,7 @@ void ToshibaAbClimate::process_sensor_value_(const DataFrame *frame) {
     for (auto &ps : this->polled_sensors_) {
       if (ps.id == id) {
         const float value = static_cast<float>(raw) * ps.scale;
-        if (id == ESTIA_FIRST_GEN_DHW_TEMP_REQUEST) {
-          this->publish_dhw_current_temperature_(value);
-        } else if (ps.sensor != nullptr) {
+        if (ps.sensor != nullptr) {
           ps.sensor->publish_state(value);
         }
         ESP_LOGD(TAG, "0x1A long:  id=0x%02X raw=0x%04X -> %.3f", id, raw, value);
@@ -3369,10 +3365,10 @@ void ToshibaAbClimate::process_received_data_estia_first_gen_(const DataFrame *f
     if (this->hotwater_resistor_heating_binary_sensor_)
       this->hotwater_resistor_heating_binary_sensor_->publish_state(this->estia_first_gen_hotwater_resistor_heating_);
     if (this->zone1_target_temperature_sensor_) this->zone1_target_temperature_sensor_->publish_state(static_cast<float>(frame->raw[10]) / 2.0f - 16.0f);
+    if (len > 12) this->publish_dhw_current_temperature_(static_cast<float>(frame->raw[12]) / 2.0f - 16.0f);
     if (len > 18 && this->zone1_water_temp_sensor_) this->zone1_water_temp_sensor_->publish_state(static_cast<float>(frame->raw[14]) / 2.0f - 16.0f);
     if (len > 14) {
-      ESP_LOGD(TAG, "Estia first-gen status temperatures: temperature 1=%.1f°C (raw 12=0x%02X), temperature 2=%.1f°C (raw 13=0x%02X), temperature 3=%.1f°C (raw 14=0x%02X)",
-               static_cast<float>(frame->raw[12]) / 2.0f - 16.0f, frame->raw[12],
+      ESP_LOGD(TAG, "Estia first-gen status temperatures: temperature 2=%.1f°C (raw 13=0x%02X), temperature 3=%.1f°C (raw 14=0x%02X)",
                static_cast<float>(frame->raw[13]) / 2.0f - 16.0f, frame->raw[13],
                static_cast<float>(frame->raw[14]) / 2.0f - 16.0f, frame->raw[14]);
     }
@@ -3383,9 +3379,7 @@ void ToshibaAbClimate::process_received_data_estia_first_gen_(const DataFrame *f
     if (this->last_sensor_query_id_ != 0xFF) {
       for (auto &ps : this->polled_sensors_) {
         if (ps.id == this->last_sensor_query_id_) {
-          if (this->last_sensor_query_id_ == ESTIA_FIRST_GEN_DHW_TEMP_REQUEST) {
-            this->publish_dhw_current_temperature_(static_cast<float>(value) * ps.scale);
-          } else if (ps.sensor != nullptr) {
+          if (ps.sensor != nullptr) {
             ps.sensor->publish_state(static_cast<float>(value) * ps.scale);
           }
           published_polled_sensor = true;

--- a/components/toshiba_ab/toshiba_ab.h
+++ b/components/toshiba_ab/toshiba_ab.h
@@ -1142,7 +1142,6 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
   bool estia_first_gen_hotwater_resistor_heating_{false};
   uint8_t estia_first_gen_dhw_encoded_{0};
   uint8_t estia_first_gen_zone1_encoded_{0};
-  static const uint8_t ESTIA_FIRST_GEN_DHW_TEMP_REQUEST = 0x0A;
   uint32_t last_temp_log_time_ = 0;  // Counter for BME280 temperature logging
   float last_sent_temp_ = 1; // Last sent room temperature to the unit
 


### PR DESCRIPTION
### Motivation
- The Estia first-generation master parameters/status frame contains DHW current temperature in `raw[12]`, so the thermostat should use that value instead of relying on a separately polled sensor id `0x0A` and the auxiliary "temperature 1" log entry.

### Description
- Publish DHW current temperature from the Estia first-gen master/status frame by decoding `frame->raw[12]` and calling `publish_dhw_current_temperature_` so the thermostat current temperature and any configured DHW sensor are updated from that frame.
- Remove the automatic polling and special-case handling for the `0x0A` DHW sensor, including dropping the `ESTIA_FIRST_GEN_DHW_TEMP_REQUEST` constant and related receive-path branches so polled sensor replies only publish to their configured sensor objects.
- Stop logging the Estia first-gen "temperature 1" value and keep only temperatures 2 and 3 in the debug status log.
- Simplify `components/toshiba_ab/climate.py` polled-sensor setup to only register sensors explicitly configured by the user and no longer auto-add the `0x0A` fallback poller.

### Testing
- Ran `python -m py_compile components/toshiba_ab/climate.py` and it succeeded.
- Ran `git diff --check` and it reported no whitespace or diff errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a472b7a73c4832f82a14f01504b8593)