### PR TITLE
Handle Estia first-gen remote status errors

### DIFF
--- a/components/toshiba_ab/toshiba_ab.cpp
+++ b/components/toshiba_ab/toshiba_ab.cpp
@@ -3257,6 +3257,16 @@ void ToshibaAbClimate::send_estia_first_gen_request_data(uint8_t request_code) {
   this->send_command(make_estia_first_gen_frame(this->remote_address_, this->master_address_, payload, sizeof(payload)));
 }
 
+void ToshibaAbClimate::estia_first_gen_reset_remote_error_() {
+  ESP_LOGI(TAG, "Estia first-gen remote error reset: resending last known DHW state (%s)",
+           this->estia_first_gen_dhw_active_ ? "on" : "off");
+  if (this->estia_first_gen_dhw_active_) {
+    this->send_estia_first_gen_dhw_on();
+  } else {
+    this->send_estia_first_gen_dhw_off();
+  }
+}
+
 void ToshibaAbClimate::process_received_data_estia_first_gen_(const DataFrame *frame) {
   if (frame == nullptr) return;
   const uint8_t len = frame->raw[0];
@@ -3320,7 +3330,12 @@ void ToshibaAbClimate::process_received_data_estia_first_gen_(const DataFrame *f
       return "Remote command: setpoint change";
     }
     if (is_remote_source && frame->raw[3] == 0xE0 && frame->raw[5] == 0x31) {
-      return "Remote status";
+      if (frame->raw[6] == 0x00) {
+        return "Remote status OK";
+      }
+      char buf[40];
+      std::snprintf(buf, sizeof(buf), "Remote status error 0x%02X", frame->raw[6]);
+      return buf;
     }
     return unknown_label();
   };
@@ -3331,9 +3346,19 @@ void ToshibaAbClimate::process_received_data_estia_first_gen_(const DataFrame *f
     ESP_LOGD(TAG, "Estia first-gen checksum fail for %s", label.c_str());
     return;
   }
-  if (this->master_address_auto_ && frame->raw[3] == 0xE0 && frame->raw[5] == 0x31) {
+  if (this->master_address_auto_ && frame->raw[3] == 0xE0 && frame->raw[5] == 0x31 && !is_remote_source) {
     this->master_address_ = src;
     this->master_address_confirmed_ = true;
+  }
+  if (is_remote_source && frame->raw[3] == 0xE0 && frame->raw[5] == 0x31) {
+    if (frame->raw[6] == 0x00) {
+      ESP_LOGD(TAG, "Estia first-gen remote status OK");
+    } else {
+      ESP_LOGW(TAG, "Estia first-gen remote status error: 0x%02X", frame->raw[6]);
+      if (frame->raw[6] == 0x49) {
+        this->estia_first_gen_reset_remote_error_();
+      }
+    }
   }
   if (this->remote_address_auto_ && src == this->remote_address_ && has_remote_ping_signature &&
       this->remote_address_ < TOSHIBA_ESTIA_REMOTE_MAX) {

--- a/components/toshiba_ab/toshiba_ab.h
+++ b/components/toshiba_ab/toshiba_ab.h
@@ -975,6 +975,7 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
   size_t send_new_state(const struct TccState *new_state);
   void sync_from_received_state();
   void autoreset_remote_error_();
+  void estia_first_gen_reset_remote_error_();
   bool is_own_tx_echo_(const DataFrame *f) const; //used to filter echo after sending frame
   void remember_tx_frame_for_echo_(const uint8_t *bytes, size_t size, bool tu2c);
   void update_frame_validation_();


### PR DESCRIPTION
### Motivation
- Distinguish first-generation Estia remote status frames so that `raw[6] == 0x00` is treated as an OK status while other values indicate an error. 
- When a specific remote error code (`0x49`) is reported, trigger an automated reset action that attempts a simple recovery by re-sending the last-known DHW on/off command. 
- Prevent master address auto-learning from using remote status frames to avoid mis-detection when the frame actually originates from a remote. 

### Description
- Added `ToshibaAbClimate::estia_first_gen_reset_remote_error_()` which logs and resends the last known DHW state by calling the existing `send_estia_first_gen_dhw_on()` or `send_estia_first_gen_dhw_off()`. 
- Declared `estia_first_gen_reset_remote_error_()` in the header (`toshiba_ab.h`). 
- Updated `process_received_data_estia_first_gen_()` to label remote status frames as `Remote status OK` when `raw[6] == 0x00`, otherwise return `Remote status error 0xXX`. 
- After checksum validation, added logging for remote status OK vs error and added a handler that calls `estia_first_gen_reset_remote_error_()` when `raw[6] == 0x49`. 
- Modified master auto-detection logic to ignore remote status frames when learning the master address by adding a `!is_remote_source` guard. 

### Testing
- `git diff --check` completed with no problems. 
- `git diff --stat` showed the two modified files and their changes. 
- `platformio run` could not be run in this environment because the `platformio` command is not available. 
- `./format.sh` reported missing repository references (`components/tcc_link/...`) so full formatting could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4735dd5f2c832fa84d89d5b3a0b2c9)