### PR TITLE
Estia: add remote_error diagnostic binary sensor and autoreset control

### DIFF
--- a/components/toshiba_ab/climate.py
+++ b/components/toshiba_ab/climate.py
@@ -69,6 +69,7 @@ CONF_ZONE1_TARGET_TEMPERATURE = "zone1_target_temperature"
 CONF_DHW_CURRENT_TEMPERATURE = "dhw_current_temperature"
 CONF_HOTWATER_PUMP_HEATING = "hotwater_pump_heating"
 CONF_HOTWATER_RESISTOR_HEATING = "hotwater_resistor_heating"
+CONF_REMOTE_ERROR = "remote_error"
 
 #AC Sensors addresses
 
@@ -254,6 +255,9 @@ CONFIG_SCHEMA = climate._CLIMATE_SCHEMA.extend(
         ),
         cv.Optional(CONF_HOTWATER_PUMP_HEATING): binary_sensor.binary_sensor_schema(),
         cv.Optional(CONF_HOTWATER_RESISTOR_HEATING): binary_sensor.binary_sensor_schema(),
+        cv.Optional(CONF_REMOTE_ERROR): binary_sensor.binary_sensor_schema(
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        ),
         cv.Optional(CONF_FAILED_CRCS): sensor.sensor_schema(
             accuracy_decimals=0,
             entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
@@ -465,6 +469,9 @@ async def to_code(config):
     if CONF_HOTWATER_RESISTOR_HEATING in config:
         sens = await binary_sensor.new_binary_sensor(config[CONF_HOTWATER_RESISTOR_HEATING])
         cg.add(var.set_hotwater_resistor_heating_binary_sensor(sens))
+    if CONF_REMOTE_ERROR in config:
+        sens = await binary_sensor.new_binary_sensor(config[CONF_REMOTE_ERROR])
+        cg.add(var.set_remote_error_binary_sensor(sens))
     if CONF_OUTDOOR_TEMPERATURE in config:
         sens = await sensor.new_sensor(config[CONF_OUTDOOR_TEMPERATURE])
         cg.add(var.set_outdoor_temp_sensor(sens))

--- a/components/toshiba_ab/toshiba_ab.cpp
+++ b/components/toshiba_ab/toshiba_ab.cpp
@@ -3353,10 +3353,16 @@ void ToshibaAbClimate::process_received_data_estia_first_gen_(const DataFrame *f
   if (is_remote_source && frame->raw[3] == 0xE0 && frame->raw[5] == 0x31) {
     if (frame->raw[6] == 0x00) {
       ESP_LOGD(TAG, "Estia first-gen remote status OK");
+      if (this->remote_error_binary_sensor_) this->remote_error_binary_sensor_->publish_state(false);
     } else {
       ESP_LOGW(TAG, "Estia first-gen remote status error: 0x%02X", frame->raw[6]);
+      if (this->remote_error_binary_sensor_) this->remote_error_binary_sensor_->publish_state(true);
       if (frame->raw[6] == 0x49) {
-        this->estia_first_gen_reset_remote_error_();
+        if (this->autoreset_errors_) {
+          this->estia_first_gen_reset_remote_error_();
+        } else {
+          ESP_LOGD(TAG, "Ignoring Estia first-gen remote error reset because autoreset_errors is disabled");
+        }
       }
     }
   }

--- a/components/toshiba_ab/toshiba_ab.h
+++ b/components/toshiba_ab/toshiba_ab.h
@@ -907,6 +907,7 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
   void set_read_only(bool en) { read_only_ = en; }
   void set_ping_enabled(bool en) { ping_enabled_ = en; }
   void set_autoreset_errors(bool en) { autoreset_errors_ = en; }
+  void set_remote_error_binary_sensor(binary_sensor::BinarySensor *sensor) { remote_error_binary_sensor_ = sensor; }
   void set_estia_source_address(uint16_t addr) { estia_source_address_ = addr; }
   void send_estia_setpoint(float target_temp);
   void send_estia_power(bool on);
@@ -1016,6 +1017,7 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
   sensor::Sensor *dhw_current_temp_sensor_{nullptr};
   binary_sensor::BinarySensor *hotwater_pump_heating_binary_sensor_{nullptr};
   binary_sensor::BinarySensor *hotwater_resistor_heating_binary_sensor_{nullptr};
+  binary_sensor::BinarySensor *remote_error_binary_sensor_{nullptr};
 
   // rx handler for 0x1A (sensor) replies (called from process_received_data)
   void process_sensor_value_(const DataFrame *frame);

--- a/estia_1st_gen_example.yaml
+++ b/estia_1st_gen_example.yaml
@@ -72,6 +72,15 @@ climate:
     failed_crcs:
       name: "Estia Failed CRCs"
 
+    # Optional: true when a first-generation remote status error is detected,
+    # false again after a remote status OK frame is received.
+    remote_error:
+      name: "Estia Remote Error"
+
+    # Optional, defaults to false. Set true to send the automatic
+    # first-generation remote error reset command after error 0x49.
+    autoreset_errors: false
+
     # First-generation Estia control switches.
     # Zone 1 controls the main space-heating/cooling zone.
     zone1_switch:


### PR DESCRIPTION
### Motivation

- Expose first-generation Estia remote-status errors to Home Assistant as a diagnostic binary sensor and allow optional automatic reset of remote errors.

### Description

- Add `CONF_REMOTE_ERROR` and wire an optional binary sensor in `components/toshiba_ab/climate.py` and the example YAML, using `ENTITY_CATEGORY_DIAGNOSTIC` and `autoreset_errors` config support.
- Add `set_remote_error_binary_sensor` setter and `remote_error_binary_sensor_` member in `components/toshiba_ab/toshiba_ab.h` to hold the sensor reference.
- Publish the remote error state from `process_received_data_estia_first_gen_` in `components/toshiba_ab/toshiba_ab.cpp`, setting the binary sensor `true` on error and `false` on OK, and gate the automatic reset call behind `autoreset_errors_` with a debug log when disabled.
- Update `estia_1st_gen_example.yaml` with `remote_error` example and document `autoreset_errors` default behavior.

### Testing

- Built the firmware for the component with `platformio`/ESPHome and the compilation succeeded. 
- Validated the example configuration with `esphome config` and it parsed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a484a5375b4832f97488760451b8d90)