### PR TITLE
Adjust Estia first-gen master detection

### DIFF
--- a/components/toshiba_ab/climate.py
+++ b/components/toshiba_ab/climate.py
@@ -176,7 +176,7 @@ def _hardware_uart_rx_pin(value):
 
 CONFIG_SCHEMA = climate._CLIMATE_SCHEMA.extend(
     {
-        cv.Optional(CONF_MASTER, default=0x00): cv.uint8_t,
+        cv.Optional(CONF_MASTER): cv.uint8_t,
         cv.Optional(CONF_REMOTE): cv.uint8_t,
         cv.Optional(CONF_MASTER_ADDRESS_AUTO, default=True): cv.boolean,
         cv.Optional(CONF_COMMAND_MODE_READ, default=0x08): cv.uint8_t,

--- a/components/toshiba_ab/toshiba_ab.cpp
+++ b/components/toshiba_ab/toshiba_ab.cpp
@@ -3277,10 +3277,11 @@ void ToshibaAbClimate::process_received_data_estia_first_gen_(const DataFrame *f
   const bool has_master_status_signature = frame->raw[3] == 0xE0 && frame->raw[5] == 0x31;
   const bool has_master_keepalive_signature = len == 0x0A && frame->raw[5] == 0x3A;
   const bool has_remote_ping_signature = frame->raw[3] == 0xE0 && frame->raw[4] == 0x41 && frame->raw[5] == 0x0C;
-  const bool is_master_source = src == this->master_address_ ||
-                                (this->master_address_auto_ &&
-                                 (has_master_status_signature || has_master_keepalive_signature));
   const bool is_remote_source = src == this->remote_address_ || (src >= 0x60 && src <= TOSHIBA_ESTIA_REMOTE_MAX);
+  const bool is_possible_master_source = !is_remote_source;
+  const bool is_master_source = src == this->master_address_ ||
+                                (this->master_address_auto_ && !this->master_address_confirmed_ &&
+                                 is_possible_master_source && has_master_keepalive_signature);
   auto unknown_label = [&]() -> std::string {
     char buf[40];
     if (is_master_source) {
@@ -3346,9 +3347,16 @@ void ToshibaAbClimate::process_received_data_estia_first_gen_(const DataFrame *f
     ESP_LOGD(TAG, "Estia first-gen checksum fail for %s", label.c_str());
     return;
   }
-  if (this->master_address_auto_ && frame->raw[3] == 0xE0 && frame->raw[5] == 0x31 && !is_remote_source) {
-    this->master_address_ = src;
-    this->master_address_confirmed_ = true;
+  if (has_master_keepalive_signature && is_possible_master_source) {
+    if (this->master_address_auto_ && !this->master_address_confirmed_ && src != this->master_address_) {
+      ESP_LOGI(TAG, "Estia first-gen master keepalive from 0x%02X; switching master address from 0x%02X",
+               src, this->master_address_);
+      this->master_address_ = src;
+    }
+    if (src == this->master_address_ && !this->master_address_confirmed_) {
+      this->master_address_confirmed_ = true;
+      ESP_LOGI(TAG, "Estia first-gen master address confirmed: 0x%02X", this->master_address_);
+    }
   }
   if (is_remote_source && frame->raw[3] == 0xE0 && frame->raw[5] == 0x31) {
     if (frame->raw[6] == 0x00) {
@@ -3455,6 +3463,7 @@ void ToshibaAbReadOnlySwitch::write_state(bool state) {
 
 void ToshibaAbClimate::set_master_address(uint8_t address) {
   this->master_address_ = address;
+  this->master_address_auto_ = false;
   this->master_address_confirmed_ = false;
 }
 


### PR DESCRIPTION
### Motivation
- Improve reliability of master identification for first-generation Estia TU2C frames by making auto-detection stricter and honoring explicit YAML `master` configuration.

### Description
- Restrict candidate master frames to non-remote sources with the Estia keepalive signature and only treat them as master candidates when `master_address_auto_` is enabled and the master has not yet been confirmed (`components/toshiba_ab/toshiba_ab.cpp`).
- When a valid keepalive is received from a possible master, switch the runtime `master_address_` to that source (if different) and set `master_address_confirmed_` so further auto changes stop, with informative `ESP_LOGI` messages (`components/toshiba_ab/toshiba_ab.cpp`).
- Make the YAML `master` option optional in the config schema so omitted values remain in auto mode (`components/toshiba_ab/climate.py`).
- When `set_master_address()` is called (explicit `master` in YAML), disable master auto-detection by clearing `master_address_auto_` and mark the address as unconfirmed so valid keepalive frames from that configured address can still confirm it (`components/toshiba_ab/toshiba_ab.cpp`).

### Testing
- Ran `python3 -m py_compile components/toshiba_ab/climate.py`, which succeeded.
- Ran `git diff --check` to validate whitespace/patch issues, which reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4862e1f13c832f98b8ab2e5a759460)