### PR TITLE
Seed protocol-specific default master addresses and make auto-mode implicit

### DIFF
--- a/components/toshiba_ab/climate.py
+++ b/components/toshiba_ab/climate.py
@@ -42,7 +42,6 @@ CONF_FAILED_CRCS = "failed_crcs"
 CONF_ON_DATA_RECEIVED = "on_data_received"
 CONF_MASTER = "master"
 CONF_REMOTE = "remote"
-CONF_MASTER_ADDRESS_AUTO = "master_address_auto"
 CONF_COMMAND_MODE_READ = "command_mode_read"
 CONF_COMMAND_MODE_WRITE = "command_mode_write"
 CONF_FRAME_FORMAT = "frame_format"
@@ -178,7 +177,6 @@ CONFIG_SCHEMA = climate._CLIMATE_SCHEMA.extend(
     {
         cv.Optional(CONF_MASTER): cv.uint8_t,
         cv.Optional(CONF_REMOTE): cv.uint8_t,
-        cv.Optional(CONF_MASTER_ADDRESS_AUTO, default=True): cv.boolean,
         cv.Optional(CONF_COMMAND_MODE_READ, default=0x08): cv.uint8_t,
         cv.Optional(CONF_COMMAND_MODE_WRITE, default=0x80): cv.uint8_t,
         cv.Optional(CONF_FRAME_FORMAT, default="auto"): cv.one_of(*FRAME_FORMATS, lower=True),
@@ -391,9 +389,7 @@ async def to_code(config):
         cg.add(var.set_master_address(config[CONF_MASTER]))
     if CONF_REMOTE in config:
         cg.add(var.set_remote_address(config[CONF_REMOTE]))
-    
-    if CONF_MASTER_ADDRESS_AUTO in config:
-        cg.add(var.set_master_address_auto(config[CONF_MASTER_ADDRESS_AUTO]))
+
     if CONF_COMMAND_MODE_READ in config:
         cg.add(var.set_command_mode_read(config[CONF_COMMAND_MODE_READ]))
     if CONF_COMMAND_MODE_WRITE in config:

--- a/components/toshiba_ab/toshiba_ab.cpp
+++ b/components/toshiba_ab/toshiba_ab.cpp
@@ -197,6 +197,7 @@ void ToshibaAbClimate::confirm_frame_format_(FrameFormat format, const char *rea
   }
   this->data_reader.set_frame_format(format);
   this->frame_format_confirmed_ = true;
+  this->apply_default_master_address_for_frame_format_();
   const char *fmt = "normal";
   switch (format) {
     case FrameFormat::TU2C: fmt = "tu2c"; break;
@@ -3463,6 +3464,7 @@ void ToshibaAbReadOnlySwitch::write_state(bool state) {
 
 void ToshibaAbClimate::set_master_address(uint8_t address) {
   this->master_address_ = address;
+  this->tu2c_master_address_ = address;
   this->master_address_auto_ = false;
   this->master_address_confirmed_ = false;
 }

--- a/components/toshiba_ab/toshiba_ab.h
+++ b/components/toshiba_ab/toshiba_ab.h
@@ -22,6 +22,7 @@ const uint32_t FRAME_SEND_MILLIS_FROM_LAST_RECEIVE = 500;
 const uint32_t FRAME_SEND_MILLIS_FROM_LAST_SEND = 500;
 
 // const uint8_t TOSHIBA_MASTER = 0x00;  replaced by master_address_ which is set up in yaml
+const uint8_t TOSHIBA_MASTER_DEFAULT = 0x00;
 const uint8_t TOSHIBA_REMOTE_DEFAULT = 0x40;
 const uint8_t TOSHIBA_REMOTE_MAX = 0x49;
 const uint8_t TOSHIBA_TU2C_REMOTE_DEFAULT = 0x50;
@@ -809,7 +810,7 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
   void setup() override;
   void loop() override;
 
-  uint8_t master_address_ = 0x00;
+  uint8_t master_address_ = TOSHIBA_MASTER_DEFAULT;
   bool master_address_confirmed_{false};
   uint8_t remote_address_{TOSHIBA_REMOTE_DEFAULT};
   bool remote_address_auto_{true};
@@ -823,9 +824,6 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
     remote_address_ = std::min(address, static_cast<uint8_t>(TOSHIBA_ESTIA_REMOTE_MAX));
     remote_address_auto_ = false;
     remote_address_confirmed_ = true;
-  }
-  void set_master_address_auto(bool auto_detect) {
-    master_address_auto_ = auto_detect;
   }
   bool get_master_address_auto() const { return master_address_auto_; }
   void set_filter_frames(bool filter_frames) {
@@ -853,14 +851,38 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
     frame_format_confirmed_ = true;
     if (format == FrameFormat::ESTIA) {
       if (remote_address_auto_) remote_address_ = TOSHIBA_ESTIA_REMOTE_DEFAULT;
-      if (master_address_auto_ && master_address_ == 0x00) master_address_ = TOSHIBA_ESTIA_MASTER_DEFAULT;
     }
+    this->apply_default_master_address_for_frame_format_();
   }
   void set_frame_format_auto() {
     data_reader.set_frame_format(FrameFormat::NORMAL);
     frame_format_auto_ = true;
     frame_format_confirmed_ = false;
   }
+ private:
+  void apply_default_master_address_for_frame_format_() {
+    if (!this->master_address_auto_ || this->master_address_confirmed_) {
+      return;
+    }
+
+    switch (this->data_reader.frame_format()) {
+      case FrameFormat::ESTIA:
+        this->master_address_ = TOSHIBA_ESTIA_MASTER_DEFAULT;
+        break;
+      case FrameFormat::TU2C:
+        this->master_address_ = TOSHIBA_TU2C_MASTER_DEFAULT;
+        this->tu2c_master_address_ = TOSHIBA_TU2C_MASTER_DEFAULT;
+        break;
+      case FrameFormat::NORMAL:
+      case FrameFormat::HM:
+      case FrameFormat::A0:
+      default:
+        this->master_address_ = TOSHIBA_MASTER_DEFAULT;
+        break;
+    }
+  }
+
+ public:
   bool is_hm_variant() const { return data_reader.frame_format() == FrameFormat::HM; }
   bool is_estia_first_gen() const { return data_reader.frame_format() == FrameFormat::ESTIA; }
 

--- a/docs/frame_formats.md
+++ b/docs/frame_formats.md
@@ -27,7 +27,11 @@ SRC:DST:OPCODE1:LEN:DATA[0..LEN-1]:CRC
 
 - `SRC` and `DST` are 8-bit source and destination addresses. Common values are
   `0x00` for the master/indoor unit and `0x40` for a wall remote or this ESP
-  when emulating one.
+  when emulating one. If `master` is omitted from YAML, the component keeps
+  address auto-detection enabled and seeds the master address from the selected
+  frame format (`0x00` for normal/HM/A0, `0x90` for TU2C, and `0x70` for
+  first-generation Estia); an explicit `master` value is never overwritten by
+  auto mode.
 - `OPCODE1` identifies the broad message type, for example `0x10` ping,
   `0x11` parameter/status command, `0x15` read envelope, `0x18` ACK, `0x1A`
   sensor value, `0x1C` status, `0x55` temperature report, or `0x58` extended
@@ -224,6 +228,8 @@ climate:
 ### Structure
 
 The `estia` option selects the component's first-generation Estia support path.
+When `master` is omitted, this format defaults the master address to `0x70`
+and keeps address auto-detection enabled.
 It uses the TU2C-style format rather than the Estia R32 A0 style and parity NONE:
 
 ```text


### PR DESCRIPTION
### Motivation
- Ensure each supported frame format seeds an appropriate default master address when `master` is not declared in YAML so auto mode uses sensible addresses for normal/HM/A0, TU2C and first-generation Estia.
- Keep explicit `master` values intact and never overridden by auto-mode behavior while avoiding adding a user-facing `auto` YAML option.

### Description
- Remove the YAML-facing `master_address_auto` option and stop exposing it in `components/toshiba_ab/climate.py` so auto mode is implicit when `master` is omitted and explicit when `master` is provided.
- Add `TOSHIBA_MASTER_DEFAULT` and use protocol-specific defaults (`0x00` for normal/HM/A0, `0x90` for TU2C, `0x70` for first-gen Estia) in `components/toshiba_ab/toshiba_ab.h` and seed them when appropriate via a new private helper `apply_default_master_address_for_frame_format_()`.
- Invoke the defaulting helper when a frame format is forced with `set_frame_format()` or confirmed by live traffic in `confirm_frame_format_()`, and only apply defaults when `master` is still in auto mode and not yet confirmed.
- Ensure `set_master_address()` disables auto mode and preserves the explicit master (also propagate the explicit address to `tu2c_master_address_` for TU2C command addressing), and update codegen in `climate.py` so the removed YAML key is not processed.
- Update documentation in `docs/frame_formats.md` to describe the implicit auto-detection behavior and the frame-format master defaults.

### Testing
- Ran `python3 -m py_compile components/toshiba_ab/climate.py`, which succeeded without syntax errors.
- Ran `git diff --check` to validate whitespace/merge issues, which reported no blocking problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a486d65fd94832f86fa0087e55b6643)