### PR TITLE
Fix first-gen Estia DHW command mappings

### DIFF
--- a/components/toshiba_ab/climate.py
+++ b/components/toshiba_ab/climate.py
@@ -63,6 +63,7 @@ CONF_DEMAND = "demand"
 CONF_DEMAND_ENABLED = "demand_enabled"
 CONF_ZONE1_SWITCH = "zone1_switch"
 CONF_DHW_BOOST = "dhw_boost"
+CONF_ANTIBACTERIA = "antibacteria"
 CONF_ZONE1_WATER_TEMPERATURE = "zone1_water_temperature"
 CONF_ZONE1_TARGET_TEMPERATURE = "zone1_target_temperature"
 CONF_DHW_CURRENT_TEMPERATURE = "dhw_current_temperature"
@@ -101,6 +102,9 @@ ToshibaAbEstiaZone1Switch = toshiba_ab_ns.class_(
 )
 ToshibaAbEstiaDhwBoostSwitch = toshiba_ab_ns.class_(
     "ToshibaAbEstiaDhwBoostSwitch", switch.Switch, cg.Component
+)
+ToshibaAbEstiaAntibacteriaSwitch = toshiba_ab_ns.class_(
+    "ToshibaAbEstiaAntibacteriaSwitch", switch.Switch, cg.Component
 )
 
 ToshibaAbOnDataReceivedTrigger = toshiba_ab_ns.class_(
@@ -228,6 +232,16 @@ CONFIG_SCHEMA = climate._CLIMATE_SCHEMA.extend(
                 cv.Schema(
                     {
                         cv.GenerateID(): cv.declare_id(ToshibaAbEstiaDhwBoostSwitch),
+                    }
+                )
+            ),
+            key=CONF_NAME,
+        ),
+        cv.Optional(CONF_ANTIBACTERIA): cv.maybe_simple_value(
+            switch._SWITCH_SCHEMA.extend(
+                cv.Schema(
+                    {
+                        cv.GenerateID(): cv.declare_id(ToshibaAbEstiaAntibacteriaSwitch),
                     }
                 )
             ),
@@ -430,6 +444,9 @@ async def to_code(config):
     if CONF_DHW_BOOST in config:
         sw = await switch.new_switch(config[CONF_DHW_BOOST], var)
         cg.add(var.set_dhw_boost_switch(sw))
+    if CONF_ANTIBACTERIA in config:
+        sw = await switch.new_switch(config[CONF_ANTIBACTERIA], var)
+        cg.add(var.set_antibacteria_switch(sw))
 
     if CONF_ON_DATA_RECEIVED in config:
         for on_data_received in config.get(CONF_ON_DATA_RECEIVED, []):

--- a/components/toshiba_ab/toshiba_ab.cpp
+++ b/components/toshiba_ab/toshiba_ab.cpp
@@ -1268,8 +1268,13 @@ void ToshibaAbClimate::setup() {
     }
     this->traits_.set_supported_fan_modes({});
     this->traits_.set_supported_swing_modes({});
-    this->traits_.set_visual_min_temperature(20);
-    this->traits_.set_visual_max_temperature(65);
+    if (this->data_reader.frame_format() == FrameFormat::ESTIA) {
+      this->traits_.set_visual_min_temperature(45);
+      this->traits_.set_visual_max_temperature(60);
+    } else {
+      this->traits_.set_visual_min_temperature(20);
+      this->traits_.set_visual_max_temperature(65);
+    }
     this->traits_.set_visual_temperature_step(0.5);
   }
   
@@ -3214,7 +3219,7 @@ static DataFrame make_estia_first_gen_frame(uint8_t src, uint8_t dst, const uint
 
 void ToshibaAbClimate::send_estia_first_gen_zone1(bool on) {
   if (this->read_only_) return;
-  const uint8_t payload[] = {0xE0, 0x01, 0x21, static_cast<uint8_t>(on ? 0x03 : 0x0A)};
+  const uint8_t payload[] = {0xE0, 0x01, 0x21, static_cast<uint8_t>(on ? 0x03 : 0x02)};
   this->send_command(make_estia_first_gen_frame(this->remote_address_, this->master_address_, payload, sizeof(payload)));
 }
 
@@ -3231,12 +3236,15 @@ void ToshibaAbClimate::send_estia_first_gen_dhw_off() {
 }
 
 void ToshibaAbClimate::send_estia_first_gen_dhw_boost(bool on) {
-  // TODO: Replace this fallback once the first-generation Estia DHW boost command is known.
-  if (on) {
-    this->send_estia_first_gen_dhw_on();
-  } else {
-    this->send_estia_first_gen_dhw_off();
-  }
+  if (this->read_only_) return;
+  const uint8_t payload[] = {0xE0, 0x01, 0x24, 0x10, static_cast<uint8_t>(on ? 0x10 : 0x00)};
+  this->send_command(make_estia_first_gen_frame(this->remote_address_, this->master_address_, payload, sizeof(payload)));
+}
+
+void ToshibaAbClimate::send_estia_first_gen_antibacteria(bool on) {
+  if (this->read_only_) return;
+  const uint8_t payload[] = {0xE0, 0x01, 0x24, 0x60, static_cast<uint8_t>(on ? 0x20 : 0x00)};
+  this->send_command(make_estia_first_gen_frame(this->remote_address_, this->master_address_, payload, sizeof(payload)));
 }
 
 void ToshibaAbClimate::send_estia_first_gen_auto_mode(bool on) {
@@ -3248,7 +3256,7 @@ void ToshibaAbClimate::send_estia_first_gen_auto_mode(bool on) {
 void ToshibaAbClimate::send_estia_first_gen_dhw_setpoint(float target_temp) {
   if (this->read_only_) return;
   uint8_t encoded = static_cast<uint8_t>(std::round((target_temp + 16.0f) * 2.0f));
-  const uint8_t payload[] = {0xE0, 0x01, 0x23, 0x08, 0x00, 0x00, 0xA0, encoded};
+  const uint8_t payload[] = {0xE0, 0x01, 0x23, 0x08, 0x00, 0x00, encoded, 0x00};
   this->send_command(make_estia_first_gen_frame(this->remote_address_, this->master_address_, payload, sizeof(payload)));
 }
 
@@ -3386,7 +3394,8 @@ void ToshibaAbClimate::process_received_data_estia_first_gen_(const DataFrame *f
   if (src == this->master_address_ && frame->raw[3] == 0xE0 && frame->raw[5] == 0x31 && len > 11) {
     this->estia_first_gen_zone1_active_ = frame->raw[6] & 0x01;
     this->estia_first_gen_dhw_active_ = frame->raw[6] & 0x02;
-    this->estia_first_gen_dhw_boost_ = this->estia_first_gen_dhw_active_;
+    this->estia_first_gen_dhw_boost_ = frame->raw[7] & 0x40;
+    this->estia_first_gen_antibacteria_ = frame->raw[7] & 0x80;
     this->estia_first_gen_auto_mode_active_ = frame->raw[7] & 0x04;
     this->estia_first_gen_hotwater_resistor_heating_ = frame->raw[8] & 0x04;
     this->estia_first_gen_hotwater_pump_heating_ = frame->raw[8] & 0x08;
@@ -3399,14 +3408,18 @@ void ToshibaAbClimate::process_received_data_estia_first_gen_(const DataFrame *f
     this->publish_state();
     if (this->zone1_switch_) this->zone1_switch_->publish_state(this->estia_first_gen_zone1_active_);
     if (this->dhw_boost_switch_) this->dhw_boost_switch_->publish_state(this->estia_first_gen_dhw_boost_);
+    if (this->antibacteria_switch_) this->antibacteria_switch_->publish_state(this->estia_first_gen_antibacteria_);
     if (this->hotwater_pump_heating_binary_sensor_)
       this->hotwater_pump_heating_binary_sensor_->publish_state(this->estia_first_gen_hotwater_pump_heating_);
     if (this->hotwater_resistor_heating_binary_sensor_)
       this->hotwater_resistor_heating_binary_sensor_->publish_state(this->estia_first_gen_hotwater_resistor_heating_);
     if (this->zone1_target_temperature_sensor_) this->zone1_target_temperature_sensor_->publish_state(static_cast<float>(frame->raw[10]) / 2.0f - 16.0f);
-    if (len > 12) this->publish_dhw_current_temperature_(static_cast<float>(frame->raw[12]) / 2.0f - 16.0f);
-    if (len > 18 && this->zone1_water_temp_sensor_) this->zone1_water_temp_sensor_->publish_state(static_cast<float>(frame->raw[14]) / 2.0f - 16.0f);
-    if (len > 14) {
+    const bool has_status_temperatures = frame->raw[0] == 0x15 && len > 18;
+    if (has_status_temperatures)
+      this->publish_dhw_current_temperature_(static_cast<float>(frame->raw[12]) / 2.0f - 16.0f);
+    if (has_status_temperatures && this->zone1_water_temp_sensor_)
+      this->zone1_water_temp_sensor_->publish_state(static_cast<float>(frame->raw[14]) / 2.0f - 16.0f);
+    if (has_status_temperatures) {
       ESP_LOGD(TAG, "Estia first-gen status temperatures: temperature 2=%.1f°C (raw 13=0x%02X)",
                static_cast<float>(frame->raw[13]) / 2.0f - 16.0f, frame->raw[13]);
     }
@@ -3446,6 +3459,10 @@ void ToshibaAbEstiaZone1Switch::write_state(bool state) {
 
 void ToshibaAbEstiaDhwBoostSwitch::write_state(bool state) {
   this->climate_->send_estia_first_gen_dhw_boost(state);
+}
+
+void ToshibaAbEstiaAntibacteriaSwitch::write_state(bool state) {
+  this->climate_->send_estia_first_gen_antibacteria(state);
 }
 
 void ToshibaAbVentSwitch::write_state(bool state) {

--- a/components/toshiba_ab/toshiba_ab.h
+++ b/components/toshiba_ab/toshiba_ab.h
@@ -910,6 +910,7 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
   void set_read_only_switch(switch_::Switch *read_only_switch) { read_only_switch_ = read_only_switch; }
   void set_zone1_switch(switch_::Switch *zone1_switch) { zone1_switch_ = zone1_switch; }
   void set_dhw_boost_switch(switch_::Switch *dhw_boost_switch) { dhw_boost_switch_ = dhw_boost_switch; }
+  void set_antibacteria_switch(switch_::Switch *antibacteria_switch) { antibacteria_switch_ = antibacteria_switch; }
 
   void set_failed_crcs_sensor(sensor::Sensor *failed_crcs_sensor) { this->failed_crcs_sensor_ = failed_crcs_sensor; }
 
@@ -943,6 +944,7 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
   void send_estia_first_gen_dhw_on();
   void send_estia_first_gen_dhw_off();
   void send_estia_first_gen_dhw_boost(bool on);
+  void send_estia_first_gen_antibacteria(bool on);
   void send_estia_first_gen_auto_mode(bool on);
   void send_estia_first_gen_request_data(uint8_t request_code);
   void send_estia_tracked_(const uint8_t *frame, size_t len, uint16_t ack_dtype);
@@ -1024,6 +1026,7 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
   switch_::Switch *read_only_switch_{nullptr};
   switch_::Switch *zone1_switch_{nullptr};
   switch_::Switch *dhw_boost_switch_{nullptr};
+  switch_::Switch *antibacteria_switch_{nullptr};
   sensor::Sensor *failed_crcs_sensor_{nullptr};
 
   sensor::Sensor *current_sensor_{nullptr}; // Sensor for current, x10 A
@@ -1162,6 +1165,7 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
   bool estia_first_gen_zone1_active_{false};
   bool estia_first_gen_dhw_active_{false};
   bool estia_first_gen_dhw_boost_{false};
+  bool estia_first_gen_antibacteria_{false};
   bool estia_first_gen_auto_mode_active_{false};
   bool estia_first_gen_hotwater_pump_heating_{false};
   bool estia_first_gen_hotwater_resistor_heating_{false};
@@ -1203,6 +1207,14 @@ class ToshibaAbEstiaZone1Switch : public switch_::Switch, public Component {
 class ToshibaAbEstiaDhwBoostSwitch : public switch_::Switch, public Component {
  public:
   ToshibaAbEstiaDhwBoostSwitch(ToshibaAbClimate *climate) { climate_ = climate; }
+ protected:
+  void write_state(bool state) override;
+  ToshibaAbClimate *climate_;
+};
+
+class ToshibaAbEstiaAntibacteriaSwitch : public switch_::Switch, public Component {
+ public:
+  ToshibaAbEstiaAntibacteriaSwitch(ToshibaAbClimate *climate) { climate_ = climate; }
  protected:
   void write_state(bool state) override;
   ToshibaAbClimate *climate_;


### PR DESCRIPTION
## Status

Ready for review/merge from my side. The branch is rebased on current `main`, the extra local retry layer has been removed, and the remaining changes are the small first-generation Estia command/status fixes tested on my unit.

## Summary

This PR ports the first small set of locally tested first-generation Estia / R410A fixes onto current `main`.

It is now rebased on top of the upstream `0x24` ACK-tracking change, so the earlier local DHW target retry/confirmation layer has been removed and command retry is left to the existing ACK-based mechanism.

## Changes

- Fix Zone1 OFF command from `0x0A` to the tested `0x02`.
- Fix DHW boost so it sends the tested `01:24:10` boost command instead of falling back to DHW on/off.
- Add optional `antibacteria:` switch using the tested `01:24:60` command.
- Decode DHW boost from status byte `raw[7] & 0x40`.
- Decode antibacteria from status byte `raw[7] & 0x80`.
- Fix first-gen DHW target setpoint payload order to `01:23:08:00:00:<target>:00`.
- Guard status-frame temperature decoding so short `0x11` status/ACK-like frames do not publish bogus temperatures.
- Set the Estia DHW climate visual range to 45-60 C, matching observed FC limits.

## Not included

- Zone1 mode selector / cooling mode is intentionally left for a separate patch.
- Zone1 delayed mode-change handling when Zone1 is currently OFF is not included here.
- No Home Assistant package or Lovelace changes are included.

## Local verification

- `python -m py_compile components/toshiba_ab/climate.py`
- `git diff --check origin/main..HEAD`

## Hardware notes

The command mappings in this PR were derived from and tested against a first-generation Toshiba Estia R410A system with an HWS-AMS54 remote on the bus. Local testing showed Zone1 on/off, DHW boost on/off, antibacteria on/off, and DHW target updates being reflected by the unit/status frames.