### PR TITLE
Track TU2C ACK opcode 0x24 in Toshiba AB climate

### DIFF
--- a/components/toshiba_ab/toshiba_ab.cpp
+++ b/components/toshiba_ab/toshiba_ab.cpp
@@ -376,7 +376,7 @@ bool ToshibaAbClimate::should_track_tu2c_command_ack_(const DataFrame &frame) co
   }
 
   // Track ACKs for TU2C/first-gen Estia write commands.
-  return frame.raw[5] == 0x21 || frame.raw[5] == 0x23 || frame.raw[5] == 0x2C;
+  return frame.raw[5] == 0x21 || frame.raw[5] == 0x23 || frame.raw[5] == 0x24 || frame.raw[5] == 0x2C;
 }
 
 bool ToshibaAbClimate::should_track_command_ack_(const DataFrame &frame) const {


### PR DESCRIPTION
### Motivation
- Ensure ACK frames for the TU2C/first-gen Estia write command with opcode `0x24` are recognized so pending commands are cleared correctly.

### Description
- Update `ToshibaAbClimate::should_track_tu2c_command_ack_` to include `frame.raw[5] == 0x24` in the set of tracked ACK opcodes alongside `0x21`, `0x23`, and `0x2C`.

### Testing
- Built the project and ran the automated unit/CI tests; build and tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a535c682ad8832fbf3efa4431797ad5)