### PR TITLE
Document Estia R410A frame format and add example YAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,18 @@
 ### (not suitable for most split systems typically using IR remotes)
 <img src="hardware/v3.2/v3_2.png" width="30%">   <img src="card.JPG" width="30%">
 
+
+## Updated code (Jul 2026) - Toshiba ESTIA R410A Heat Pumps Support
+
+Thanks to [@JuhaniVu](https://github.com/JuhaniVu), the first-generation Toshiba ESTIA R410A frame format is now fully implemented in this component. In YAML this protocol is selected with `frame_format: estia` and the UART must use `parity: NONE` (2400 baud, 8N1).
+
+See [`estia_R410A.yaml`](estia_R410A.yaml) for a complete first-generation / R410A ESTIA example configuration.
+
 ## Updated code (May 2026) - Toshiba ESTIA R32 Heat Pumps Support and more
 
 Thanks to [@7tobias](https://github.com/7tobias) the code now supports interfacing with Toshiba R32 Estia Heat Pumps, the board has been tested with the R32 ESTIA Series 1.
 The protocol in ESTIA Heat Pumps changed with the introduction of R32 pumps around 2021.
-Older ESTIA models using R410A use a different protocol. Have a look at https://github.com/vakkeli/toshiba_uart_ctrl for R410 models, [@vakkeli](https://github.com/vakkeli) integration should be compatible with this board (with the correct UART pins setup in yaml)
-Have a look at the bottom of this page for details and to the example_estia.yaml for setup.
+Older ESTIA models using R410A use the first-generation ESTIA frame format, now supported directly by this component as `frame_format: estia` with UART `parity: NONE`. Have a look at the bottom of this page for details and to `estia_R410A.yaml` for setup.
 
 - The esp will now detect what protocol is in use on the AB line automatically, if none is specified.
 - Adress assignment has changed to avoid duplicated adresses that would trigger an E09 error.
@@ -110,8 +116,8 @@ If you want to help test the board with the TU2C protocol, see: https://github.c
 
 ## Estia heat pumps
 
-Thanks to [@7tobias](https://github.com/7tobias) this component also supports Toshiba R32 Estia heat pumps that use a variation of the TU2C protocol, different to that of previous R410A ESTIA pumps. See below for yaml configuration instructions.
-Older ESTIA models using R410A use a different protocol. Have a look at https://github.com/vakkeli/toshiba_uart_ctrl for R410 models, [@vakkeli](https://github.com/vakkeli) integration should be compatible with this board (with the correct UART pins setup in yaml). Happy to integrate that protocol into this repo if someone wants to run the tests.
+Thanks to [@7tobias](https://github.com/7tobias) this component also supports Toshiba R32 Estia heat pumps that use a variation of the TU2C protocol, different to that of previous R410A ESTIA pumps. See below for YAML configuration instructions.
+Thanks to [@JuhaniVu](https://github.com/JuhaniVu), older ESTIA models using R410A are now supported directly through the first-generation ESTIA frame format. Select it in YAML with `frame_format: estia` and configure the UART with `parity: NONE`. See `estia_R410A.yaml` for a complete example.
 
 
 # Installation
@@ -281,6 +287,27 @@ climate:
 ```
 
 See `example_estia.yaml` for a complete configuration including optional 0-10V demand emulation and runtime switches.
+
+## Estia R410A / first-generation YAML configuration
+
+First-generation Toshiba ESTIA R410A systems use the `estia` frame format. This format is not auto-detected, so set `frame_format: estia` explicitly and use UART `parity: NONE`.
+
+```yaml
+uart:
+  tx_pin: GPIO15
+  rx_pin: GPIO13
+  baud_rate: 2400
+  parity: NONE
+  rx_buffer_size: 2048
+
+climate:
+  - platform: toshiba_ab
+    name: "Toshiba Estia R410A"
+    id: toshiba_estia
+    frame_format: estia
+```
+
+See `estia_R410A.yaml` for a complete first-generation / R410A configuration.
 
 ## Estia protocol details
 

--- a/estia_R410A.yaml
+++ b/estia_R410A.yaml
@@ -1,0 +1,172 @@
+###############################################################################
+# Complete ESPHome config example for Toshiba Estia R410A heat pumps
+# using first-generation Estia frames on the AB-bus.
+#
+# Hardware: makusets "Toshiba AB D1 Mini" board or similar
+# Protocol: Estia first-generation TU2C-style protocol at 2400 baud 8N1
+# Important: this is NOT the R32 Estia A0 protocol. For R32/A0 systems, use
+# example_estia.yaml instead.
+###############################################################################
+
+substitutions:
+  device_name: toshiba-estia-r410a
+  friendly_name: "Toshiba Estia R410A"
+
+esphome:
+  name: ${device_name}
+  friendly_name: ${friendly_name}
+
+esp8266:
+  board: esp12e
+
+# Disable serial logging so the hardware UART is available for the AB bus.
+logger:
+  baud_rate: 0
+  level: DEBUG
+
+api:
+
+ota:
+  password: "your_ota_password"
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+  ap:
+    ssid: "Estia R410A Fallback"
+    password: "your_ap_password"
+
+web_server:
+  port: 80
+
+external_components:
+  - source:
+      type: git
+      url: https://github.com/makusets/esphome-toshiba-ab
+    refresh: 0s
+
+# AB-bus UART for Estia first-generation frames.
+# Use parity NONE for R410A Estia frames.
+# Adjust the pins for your board revision if needed.
+uart:
+  tx_pin: GPIO15
+  rx_pin: GPIO13
+  baud_rate: 2400
+  parity: NONE
+  rx_buffer_size: 2048
+
+climate:
+  - platform: toshiba_ab
+    name: ${friendly_name}
+    id: toshiba_estia
+
+    # Required for R410A Estia frames.
+    # This format is not auto-detected, so set it explicitly.
+    frame_format: estia
+
+    # Diagnostic binary sensor: true when valid traffic has been seen.
+    connected:
+      name: "Estia Connected"
+
+    # Diagnostic sensor: number of frames that failed checksum/CRC validation.
+    failed_crcs:
+      name: "Estia Failed CRCs"
+
+    # Optional: true when a first-generation remote status error is detected,
+    # false again after a remote status OK frame is received.
+    remote_error:
+      name: "Estia Remote Error"
+
+    # Optional, defaults to false. Set true to send the automatic
+    # first-generation remote error reset command after error 0x49.
+    autoreset_errors: false
+
+    # First-generation Estia control switches.
+    # Zone 1 controls the main space-heating/cooling zone.
+    zone1_switch:
+      name: "Estia Zone 1"
+
+    # Switch to activate boost mode for domestic-hot-water operation. In the current first-gen
+    # implementation this uses the known DHW on/off command fallback, as boost command still unknown.
+    dhw_boost:
+      name: "Estia DHW Boost"
+      
+    # Read-only Zone 1 values decoded from status frames
+    zone1_water_temperature:
+      name: "Toshiba Estia Zone 1 Water Temperature"
+    zone1_target_temperature:
+      name: "Toshiba Estia Zone 1 Target Temperature"
+
+
+    # Heating-state binary sensors decoded from hot-water status flags.
+    hotwater_pump_heating:
+      name: "Estia Hot Water Pump Heating"
+
+    hotwater_resistor_heating:
+      name: "Estia Hot Water Resistor Heating"
+
+
+    # Optional generic first-generation Estia sensor queries. These poll sensor
+    # IDs through the Estia data-query command and publish the returned raw value
+    # multiplied by the scale below. Not every unit supports every ID; watch logs
+    # for "sensor not available" responses and remove unsupported entries.
+    sensors:
+      - address: 0x6A           # Required for every sensor added, in this case, AC current sensor of the external unit
+        scale: 0.1              # default 1.0; here we decode raw/10 as current is reported in deciAmps
+        interval: 30s           # default 5min
+        sensor:
+          name: "Estia System Current"  #required
+          id: toshiba_current  #optional, but needed if used later in other yaml entries
+
+          #all other available options of sensor in esphome:
+
+          unit_of_measurement: "A"  #optional, defaults none
+          accuracy_decimals: 2  #optional
+          device_class: current  #optional but recommended for HA
+          state_class: measurement  #optional but recommended for HA
+
+      - address: 0x61        # Required for every sensor added, in this case, outdoor temperature sensor of the external unit
+        sensor:
+          name: "Estia Outdoor Temperature" #required
+          unit_of_measurement: "°C" 
+
+
+
+#********************** Possible sensor addresses, not all of them available in all units ****************************************
+
+
+# Control temperature (Hot water cylinder)  = 0x00
+# Control temperature (Zone1)  = 0x01
+# Control temperature (Zone2)  = 0x02
+# Remote controller sensor temperature  = 0x03
+# Condensed temperature (TC)  = 0x04
+# Water inlet temperature (TWI) = 0x06
+# Water outlet temperature (TWO)  =  0x07
+# Water heater outlet temperature (THO) = 0x08
+# Floor inlet temperature (TFI)  = 0x09
+# Hot water cylinder temperature (TTW)  = 0x0A
+# Mixing valve position  =   0x0B
+# Low pressure (Ps) × 1/10   =   0x0E
+
+# Heat exchange temperature (TE) = 0x60
+# Outside air temperature (TO)   = 0x61
+# Discharge temperature (TD) = 0x62
+# Suction temperature (TS)   = 0x63
+# Heat sink temperature (THS)    = 0x65
+# Current × 10   = 0x6A
+# Heat exchanger coil temperature (TL)   = 0x6D
+# Compressor operation Hz    =   0x70
+# Number of revolutions of outdoor fan   =   0x72
+# Outdoor PMV position × 1/10   =   0x74
+# Discharge pressure (PD) × 1/10  =   0x7A
+
+# Micro computer energized accumulation   (time × 1/100)  =   0xF0
+# Hot water compressor ON accumulation    (time × 1/100)  =   0xF1
+# Cooling compressor ON accumulation  (time × 1/100)  =   0xF2
+# Heating compressor ON accumulation  (time × 1/100)  =   0xF3
+# Built-in AC pump operation accumulation (time × 1/100)  =   0xF4
+# Hot water cylinder heater operation accumulation (time × 1/100) =   0xF5
+# Backup heater operation accumulation (time × 1/100) =   0xF6
+# Booster heater operation accumulation (time × 1/100)    =   0xF7
+
+


### PR DESCRIPTION
### Motivation
- The first-generation Estia (R410A) frame format is now implemented and needs documentation and a ready-to-use example so users can configure `frame_format: estia` with the correct UART parity. 
- The format is not auto-detected and requires `parity: NONE`, so a clear README entry and example file reduce user error. 

### Description
- Add `estia_R410A.yaml` as a complete example configuration for first-generation / R410A Estia systems with `baud_rate: 2400` and `parity: NONE`, and an explicit `frame_format: estia`. 
- Add a README section `Updated code (Jul 2026)` that thanks `@JuhaniVu`, documents the R410A support, and links to `estia_R410A.yaml`. 
- Insert a short README YAML snippet explaining that `estia` must be set explicitly and showing the required UART settings. 

### Testing
- Ran `ruby -e 'require "yaml"; YAML.load_file("estia_R410A.yaml", aliases: true); puts "estia_R410A.yaml: OK"'` which succeeded. 
- Ran `python3 -m py_compile components/toshiba_ab/climate.py` which succeeded. 
- Attempted to validate YAML with Python (`yaml.safe_load`) but the environment is missing the `PyYAML` module, so that check was skipped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5a11b373a8832f9c962040bbaf7d55)