### PR TITLE
Update TU2C changelog and contributor credits

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,11 @@ ESTIA hydronic heat-pump systems that communicate over the two-wire **AB bus**.
 
 ## Changelog
 
-### July 2026 — ESTIA R410A support
+### July 2026 — TU2C and ESTIA R410A support
+
+The TU2C protocol is now fully functional, thanks to contributions from
+[@yvertman](https://github.com/yvertman) and
+[@Dieghito72](https://github.com/Dieghito72).
 
 Thanks to [@JuhaniVu](https://github.com/JuhaniVu), the first-generation Toshiba
 ESTIA R410A frame format is fully implemented. Select `frame_format: estia` and
@@ -225,5 +229,7 @@ ESPHome component by [@muxa](https://github.com/muxa) in
 Special thanks to [@7tobias](https://github.com/7tobias) for ESTIA R32 support,
 [@JuhaniVu](https://github.com/JuhaniVu) for first-generation/R410A ESTIA support,
 [@mtthidoteu](https://github.com/mtthidoteu) for HM support and hardware UART
-improvements, and every contributor and tester who has shared hardware findings,
-models, captures, code and documentation.
+improvements, and [@yvertman](https://github.com/yvertman) and
+[@Dieghito72](https://github.com/Dieghito72) for their contributions to fully
+functional TU2C support. Thanks also to every contributor and tester who has
+shared hardware findings, models, captures, code and documentation.


### PR DESCRIPTION
### Motivation

- Announce that TU2C support is now fully functional and give credit to contributors in the project documentation.

### Description

- Update `README.md` July 2026 changelog heading to mention TU2C and add a short paragraph crediting `@yvertman` and `@Dieghito72` for TU2C work.
- Add `@yvertman` and `@Dieghito72` to the README "Credits and thanks" section to acknowledge their contributions to TU2C support.

### Testing

- Ran `git diff --check` to ensure there are no whitespace or diff errors and it completed without issues.
- Attempted to run `markdownlint README.md` but no Markdown linter is installed in the environment, so the lint step was skipped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5daf4bcd94832fb57b30f976d89eaf)