### PR TITLE
Power cycle normal TCC-Link units during error autoreset

### DIFF
--- a/components/toshiba_ab/toshiba_ab.cpp
+++ b/components/toshiba_ab/toshiba_ab.cpp
@@ -1517,15 +1517,42 @@ void ToshibaAbClimate::sync_from_received_state() {
 }
 
 void ToshibaAbClimate::autoreset_remote_error_() {
-  ESP_LOGI(TAG, "Autoreset errors: resending current mode/fan/target temperature");
   auto command = DataFrame{};
   if (this->data_reader.frame_format() == FrameFormat::TU2C) {
+    ESP_LOGI(TAG, "Autoreset errors: resending current mode/fan/target temperature");
     write_set_parameter_flags_tu2c(&command, this->tu2c_remote_address_, this->tu2c_master_address_, &this->tcc_state,
                                    COMMAND_SET_TEMP | COMMAND_SET_FAN);
-  } else {
-    write_set_parameter_flags(&command, this->remote_address_, this->master_address_, this->command_mode_read_, &this->tcc_state,
-                              COMMAND_SET_TEMP | COMMAND_SET_FAN, this->is_hm_variant());
+    this->send_command(command);
+    return;
   }
+
+  // A normal TCC-Link remote clears error 0x49 by cycling the unit's power.
+  // Snapshot all settings before queuing the power-off command so subsequent
+  // status reports cannot change the state that will be restored.
+  const TccState last_state = this->tcc_state;
+  TccState power_state = last_state;
+
+  ESP_LOGI(TAG, "Autoreset errors: power cycling and restoring mode/fan/target temperature/vent");
+  power_state.power = POWER_OFF;
+  write_set_parameter_power(&command, this->remote_address_, this->master_address_, this->command_mode_read_, &power_state);
+  this->send_command(command);
+
+  power_state.power = POWER_ON;
+  command = DataFrame{};
+  write_set_parameter_power(&command, this->remote_address_, this->master_address_, this->command_mode_read_, &power_state);
+  this->send_command(command);
+
+  command = DataFrame{};
+  write_set_parameter_mode(&command, this->remote_address_, this->master_address_, this->command_mode_read_, &last_state);
+  this->send_command(command);
+
+  command = DataFrame{};
+  write_set_parameter_flags(&command, this->remote_address_, this->master_address_, this->command_mode_read_, &last_state,
+                            COMMAND_SET_TEMP | COMMAND_SET_FAN, this->is_hm_variant());
+  this->send_command(command);
+
+  command = DataFrame{};
+  write_set_parameter_vent(&command, this->remote_address_, this->master_address_, this->command_mode_read_, &last_state);
   this->send_command(command);
 }
 


### PR DESCRIPTION
### Motivation
- Normal TCC-Link remotes clear remote error `0x49` by cycling power, so the autoreset should replicate that behavior for non-TU2C frames to reliably clear the error and avoid missed state restores.
- TU2C/first-generation Estia autoreset behavior should remain unchanged and continue to resend mode/fan/target values.

### Description
- Changed `ToshibaAbClimate::autoreset_remote_error_()` to snapshot the current `TccState` and, for normal TCC-Link frames, enqueue a power-off then power-on sequence followed by restoring the previous mode, fan, target temperature, and ventilation state via `write_set_parameter_power`, `write_set_parameter_mode`, `write_set_parameter_flags`, and `write_set_parameter_vent`.
- Preserved the existing TU2C path which still logs and resends current mode/fan/target temperature via `write_set_parameter_flags_tu2c` and returns early.
- Added `ESP_LOGI` messages to indicate the autoreset actions and the power-cycling restore step.

### Testing
- Ran `git diff --check` with no reported issues.
- Ran `python3 -m compileall -q components/toshiba_ab` which completed successfully.
- `platformio run` was not executed in this environment because PlatformIO is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6d49a63018832f94b2e88106363125)