### PR TITLE
Add reader diagnostics: reset rate and 5-minute CRC failure counter

### DIFF
--- a/components/toshiba_ab/climate.py
+++ b/components/toshiba_ab/climate.py
@@ -39,6 +39,8 @@ CONF_CONNECTED = "connected"
 CONF_VENT = "vent"
 CONF_READ_ONLY_SWITCH = "read_only_switch"
 CONF_FAILED_CRCS = "failed_crcs"
+CONF_READER_RESET_RATE = "reader_reset_rate"
+CONF_CRC_FAILURES_5MIN = "crc_failures_5min"
 
 CONF_ON_DATA_RECEIVED = "on_data_received"
 CONF_MASTER = "master"
@@ -277,6 +279,20 @@ CONFIG_SCHEMA = climate._CLIMATE_SCHEMA.extend(
             entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
             state_class=STATE_CLASS_MEASUREMENT,
         ),
+        # Reader health entities are created for every component instance so
+        # users do not need to opt in from YAML.
+        cv.Optional(CONF_READER_RESET_RATE, default={"name": "Toshiba Reader Reset Rate"}): sensor.sensor_schema(
+            unit_of_measurement="resets/min",
+            accuracy_decimals=2,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        cv.Optional(CONF_CRC_FAILURES_5MIN, default={"name": "Toshiba CRC Failures (5 min)"}): sensor.sensor_schema(
+            unit_of_measurement="failures/5min",
+            accuracy_decimals=0,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
         cv.Optional(CONF_ON_DATA_RECEIVED): automation.validate_automation(
             {
                cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(ToshibaAbOnDataReceivedTrigger),
@@ -433,6 +449,11 @@ async def to_code(config):
     if CONF_FAILED_CRCS in config:
         sens = await sensor.new_sensor(config[CONF_FAILED_CRCS])
         cg.add(var.set_failed_crcs_sensor(sens))
+
+    reset_rate = await sensor.new_sensor(config[CONF_READER_RESET_RATE])
+    cg.add(var.set_reader_reset_rate_sensor(reset_rate))
+    crc_rate = await sensor.new_sensor(config[CONF_CRC_FAILURES_5MIN])
+    cg.add(var.set_crc_failures_5min_sensor(crc_rate))
 
     if CONF_VENT in config:
         sw = await switch.new_switch(config[CONF_VENT], var)

--- a/components/toshiba_ab/climate.py
+++ b/components/toshiba_ab/climate.py
@@ -39,7 +39,7 @@ CONF_CONNECTED = "connected"
 CONF_VENT = "vent"
 CONF_READ_ONLY_SWITCH = "read_only_switch"
 CONF_FAILED_CRCS = "failed_crcs"
-CONF_READER_RESET_RATE = "reader_reset_rate"
+CONF_NOISE_RATE = "noise_rate"
 CONF_CRC_FAILURES_5MIN = "crc_failures_5min"
 
 CONF_ON_DATA_RECEIVED = "on_data_received"
@@ -281,8 +281,8 @@ CONFIG_SCHEMA = climate._CLIMATE_SCHEMA.extend(
         ),
         # Reader health entities are created for every component instance so
         # users do not need to opt in from YAML.
-        cv.Optional(CONF_READER_RESET_RATE, default={"name": "Toshiba Reader Reset Rate"}): sensor.sensor_schema(
-            unit_of_measurement="resets/min",
+        cv.Optional(CONF_NOISE_RATE, default={"name": "Toshiba Noise Rate"}): sensor.sensor_schema(
+            unit_of_measurement="errors/min",
             accuracy_decimals=2,
             entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
             state_class=STATE_CLASS_MEASUREMENT,
@@ -450,8 +450,8 @@ async def to_code(config):
         sens = await sensor.new_sensor(config[CONF_FAILED_CRCS])
         cg.add(var.set_failed_crcs_sensor(sens))
 
-    reset_rate = await sensor.new_sensor(config[CONF_READER_RESET_RATE])
-    cg.add(var.set_reader_reset_rate_sensor(reset_rate))
+    noise_rate = await sensor.new_sensor(config[CONF_NOISE_RATE])
+    cg.add(var.set_noise_rate_sensor(noise_rate))
     crc_rate = await sensor.new_sensor(config[CONF_CRC_FAILURES_5MIN])
     cg.add(var.set_crc_failures_5min_sensor(crc_rate))
 

--- a/components/toshiba_ab/toshiba_ab.cpp
+++ b/components/toshiba_ab/toshiba_ab.cpp
@@ -1276,7 +1276,7 @@ void ToshibaAbClimate::setup() {
     this->failed_crcs_sensor_->publish_state(0);
   }
   this->last_diagnostics_publish_ms_ = millis();
-  if (this->reader_reset_rate_sensor_ != nullptr) this->reader_reset_rate_sensor_->publish_state(0);
+  if (this->noise_rate_sensor_ != nullptr) this->noise_rate_sensor_->publish_state(0);
   if (this->crc_failures_5min_sensor_ != nullptr) this->crc_failures_5min_sensor_->publish_state(0);
   ESP_LOGD("toshiba", "Setting up ToshibaClimate...");
 
@@ -2484,10 +2484,10 @@ void ToshibaAbClimate::publish_reader_diagnostics_() {
   const uint32_t now = millis();
   const uint32_t elapsed_ms = now - this->last_diagnostics_publish_ms_;
   this->last_diagnostics_publish_ms_ = now;
-  const uint32_t resets = this->data_reader.consume_reset_count();
+  const uint32_t noise_errors = this->data_reader.consume_reset_count();
 
-  if (this->reader_reset_rate_sensor_ != nullptr) {
-    this->reader_reset_rate_sensor_->publish_state(elapsed_ms == 0 ? 0.0f : resets * 60000.0f / elapsed_ms);
+  if (this->noise_rate_sensor_ != nullptr) {
+    this->noise_rate_sensor_->publish_state(elapsed_ms == 0 ? 0.0f : noise_errors * 60000.0f / elapsed_ms);
   }
 
   this->crc_history_counts_[this->crc_history_next_] = this->crc_failure_count_;

--- a/components/toshiba_ab/toshiba_ab.cpp
+++ b/components/toshiba_ab/toshiba_ab.cpp
@@ -1265,6 +1265,7 @@ void ToshibaAbClimate::dump_config() {
   ESP_LOGCONFIG(TAG, "  Polled sensors configured: %zu", this->polled_sensors_.size());
   ESP_LOGCONFIG(TAG, "  Connected sensor: %s", this->connected_binary_sensor_ ? "yes" : "no");
   ESP_LOGCONFIG(TAG, "  Failed CRCs sensor: %s", this->failed_crcs_sensor_ ? "yes" : "no");
+  ESP_LOGCONFIG(TAG, "  Reader diagnostics: enabled (30s updates)");
   ESP_LOGCONFIG(TAG, "  Filter alert sensor: %s", this->filter_alert_sensor_ ? "yes" : "no");
   ESP_LOGCONFIG(TAG, "  Vent switch: %s", this->vent_switch_ ? "yes" : "no");
   ESP_LOGCONFIG(TAG, "  Read-only switch: %s", this->read_only_switch_ ? "yes" : "no");
@@ -1274,6 +1275,9 @@ void ToshibaAbClimate::setup() {
   if (this->failed_crcs_sensor_ != nullptr) {
     this->failed_crcs_sensor_->publish_state(0);
   }
+  this->last_diagnostics_publish_ms_ = millis();
+  if (this->reader_reset_rate_sensor_ != nullptr) this->reader_reset_rate_sensor_->publish_state(0);
+  if (this->crc_failures_5min_sensor_ != nullptr) this->crc_failures_5min_sensor_->publish_state(0);
   ESP_LOGD("toshiba", "Setting up ToshibaClimate...");
 
   // Restore last-known mode/target_temp/fan_mode from preferences so we never
@@ -2036,9 +2040,7 @@ bool ToshibaAbClimate::receive_data_frame(const struct DataFrame *frame) {
           ESP_LOGD(TAG, "  dtype=%02X:%02X", frame->raw[7], frame->raw[8]);
         }
       }
-      if (this->failed_crcs_sensor_ != nullptr) {
-        this->failed_crcs_sensor_->publish_state(this->failed_crcs_sensor_->state + 1);
-      }
+      this->record_crc_failure_();
       return false;
     }
     uint8_t frame_type = frame->raw[0];
@@ -2418,6 +2420,16 @@ bool ToshibaAbClimate::receive_data_frame(const struct DataFrame *frame) {
 
     return true;
   }
+  // Wrapped TU2C and first-generation Estia frames both carry an additive
+  // checksum as the final byte before the (already stripped) A0 delimiter.
+  if (frame->is_tu2c()) {
+    const size_t size = frame->size();
+    if (size < 2 || frame->raw[size - 1] != calculate_tu2c_crc(frame->raw, size - 1)) {
+      ESP_LOGW(TAG, "TU2C checksum failed");
+      this->record_crc_failure_();
+      return false;
+    }
+  }
   DataFrame auto_detected_frame{};
   if (this->should_auto_detect_frame_format_() && this->is_hm_wire_frame_from_master_(frame)) {
     auto_detected_frame = *frame;
@@ -2427,14 +2439,12 @@ bool ToshibaAbClimate::receive_data_frame(const struct DataFrame *frame) {
   }
 
   if (!frame->is_tu2c() && frame->crc() != frame->calculate_crc()) {
-    if (this->failed_crcs_sensor_ != nullptr) {
-      this->failed_crcs_sensor_->publish_state(this->failed_crcs_sensor_->state + 1);
-    }
     // Classic TCC-Link: the XOR CRC is the unit's actual algorithm, so a
     // mismatch means the frame is corrupt — drop it. The HM variant uses
     // a different (still-undecoded) CRC algorithm, so every frame fails
     // the XOR check by design; tolerate the mismatch and process anyway.
     if (!this->is_hm_variant()) {
+      this->record_crc_failure_();
       ESP_LOGW(TAG, "CRC check failed");
       log_data_frame("Failed frame", frame);
       return false;
@@ -2463,7 +2473,38 @@ bool ToshibaAbClimate::receive_data_frame(const struct DataFrame *frame) {
 }
 
 
+void ToshibaAbClimate::record_crc_failure_() {
+  this->crc_failure_count_++;
+  if (this->failed_crcs_sensor_ != nullptr) {
+    this->failed_crcs_sensor_->publish_state(this->failed_crcs_sensor_->state + 1);
+  }
+}
+
+void ToshibaAbClimate::publish_reader_diagnostics_() {
+  const uint32_t now = millis();
+  const uint32_t elapsed_ms = now - this->last_diagnostics_publish_ms_;
+  this->last_diagnostics_publish_ms_ = now;
+  const uint32_t resets = this->data_reader.consume_reset_count();
+
+  if (this->reader_reset_rate_sensor_ != nullptr) {
+    this->reader_reset_rate_sensor_->publish_state(elapsed_ms == 0 ? 0.0f : resets * 60000.0f / elapsed_ms);
+  }
+
+  this->crc_history_counts_[this->crc_history_next_] = this->crc_failure_count_;
+  this->crc_failure_count_ = 0;
+  this->crc_history_next_ = (this->crc_history_next_ + 1) % CRC_HISTORY_SIZE;
+
+  uint32_t failures_5min = 0;
+  for (const uint32_t count : this->crc_history_counts_) {
+    failures_5min += count;
+  }
+  if (this->crc_failures_5min_sensor_ != nullptr) {
+    this->crc_failures_5min_sensor_->publish_state(failures_5min);
+  }
+}
+
 void ToshibaAbClimate::loop() {
+  if (millis() - this->last_diagnostics_publish_ms_ >= 30000) this->publish_reader_diagnostics_();
   // TODO: check if last_unconfirmed_command_ was not confirmed after a timeout
   // and log warning/error
 
@@ -2710,7 +2751,7 @@ void ToshibaAbClimate::loop() {
         if (!receive_data_frame(&frame)) {
         }
 
-        data_reader.reset();
+        data_reader.reset(false);
 
         // read next packet (if any in the next loop)
         // the smallest packet (ALIVE) is 32ms wide,
@@ -2752,7 +2793,8 @@ void ToshibaAbClimate::loop() {
           // data_reader.frame.raw, data_reader.data_index_);
         }
         can_read_packet = true;
-        data_reader.reset();
+        const bool incomplete_frame = !data_reader.complete && data_reader.data_index_ > 0;
+        data_reader.reset(incomplete_frame);
         last_read_millis_ = 0;
       }
     }

--- a/components/toshiba_ab/toshiba_ab.h
+++ b/components/toshiba_ab/toshiba_ab.h
@@ -325,8 +325,12 @@ struct DataFrameReader {
   uint8_t normal_replay_count_{0};
   uint32_t estia_last_byte_ms_{0};
   static const uint32_t ESTIA_BYTE_TIMEOUT_MS = 20;  // inter-byte timeout: ~4 byte-times at 2400 baud
+  uint32_t reset_count_{0};
 
-  void reset() {
+  // Clear reader state. Successful frame completion and configuration changes
+  // pass false so only recovery/error resets contribute to the diagnostic rate.
+  void reset(bool count_as_error) {
+    if (count_as_error) count_reset();
     reset_frame_state_();
     tu2c_      = false;
     prefix_match_ = 0;
@@ -367,10 +371,7 @@ struct DataFrameReader {
       if (estia_ && (millis() - estia_last_byte_ms_) > ESTIA_BYTE_TIMEOUT_MS) {
         ESP_LOGV("READER", "Estia inter-byte timeout after %ums gap (%u/%u bytes); resync",
                  (unsigned)(millis() - estia_last_byte_ms_), data_index_, estia_expected_total_);
-        estia_ = false;
-        data_index_ = 0;
-        estia_expected_total_ = 0;
-        prefix_match_ = 0;
+        reset(true);
         // Don't return — process this byte as potential new frame start below
       }
       // Wait for A0 prefix
@@ -402,7 +403,7 @@ struct DataFrameReader {
           frame.raw[data_index_] = byte;
         } else {
           ESP_LOGV("READER", "Estia frame buffer overflow; resetting");
-          reset();
+          reset(true);
           return false;
         }
 
@@ -412,7 +413,7 @@ struct DataFrameReader {
           frame.set_estia_len(byte);  // store outside union so raw[3] won't clobber it
           if (estia_expected_total_ < 6 || estia_expected_total_ > DATA_FRAME_MAX_SIZE) {
             ESP_LOGV("READER", "Invalid Estia length 0x%02X; resetting", byte);
-            reset();
+            reset(true);
             return false;
           }
         }
@@ -473,7 +474,7 @@ struct DataFrameReader {
         tu2c_len_pending_ = false;
         if (tu2c_expected_total_ < 1 || (tu2c_expected_total_ - 1) > DATA_FRAME_MAX_SIZE) {
           ESP_LOGV("READER", "Invalid TU2C length 0x%02X; resetting reader", current_byte);
-          reset();
+          reset(true);
           return false;
         }
         frame.raw[data_index_] = current_byte;
@@ -487,7 +488,7 @@ struct DataFrameReader {
         if (current_byte != 0xA0) {
           ESP_LOGV("READER", "TU2C frame ended without 0xA0 (seen=%u expected=%u); resetting",
                    tu2c_bytes_seen_, tu2c_expected_total_);
-          reset();
+          reset(true);
           return false;
         }
         // Do not assign frame.data_length for TU2C/first-generation Estia frames:
@@ -507,7 +508,7 @@ struct DataFrameReader {
 
       if (tu2c_expected_total_ > 0 && tu2c_bytes_seen_ > tu2c_expected_total_) {
         ESP_LOGV("READER", "TU2C frame exceeded expected length; resetting");
-        reset();
+        reset(true);
         return false;
       }
     }
@@ -515,6 +516,7 @@ struct DataFrameReader {
     // Optionally filter obvious invalid source values at frame start.
     if (!use_tu2c && data_index_ == 0 && filter_frames_ && current_byte > 0xA0) {
       ESP_LOGV("READER", "Ignoring packet with out-of-range source: 0x%02X", current_byte);
+      reset(true);
       return false;
     }
     if (frame_format_ == FrameFormat::NORMAL && handle_normal_restart_candidates_(current_byte)) {
@@ -549,7 +551,7 @@ struct DataFrameReader {
       if (!allow_same_source_dest_ && frame.raw[0] == frame.raw[1]) {
           ESP_LOGV("READER", "Ignoring packet where source == dest: 0x%02X", frame.raw[0]);
           // reset reader state so next byte is treated as new frame start
-          reset();
+          reset(true);
           return false;
       }
     }
@@ -560,7 +562,7 @@ struct DataFrameReader {
       if (!frame.validate_bounds()) {    // early length sanity check
         ESP_LOGV("READER", "Invalid length 0x%02X; resetting reader", frame.data_length);
         // Resync
-        reset();
+        reset(true);
         return false;
       }
       expected_total_ = DATA_OFFSET_FROM_START + frame.data_length + 1;  // 4 + len + crc
@@ -617,7 +619,7 @@ struct DataFrameReader {
     // Guard against runaway input
     if (data_index_ == DATA_FRAME_MAX_SIZE) {
       ESP_LOGW("READER", "Went over buffer; resetting");
-      reset();
+      reset(true);
     }
 
     return false;
@@ -653,9 +655,15 @@ struct DataFrameReader {
   void set_allow_same_source_dest(bool allow_same) { allow_same_source_dest_ = allow_same; }
   void set_frame_format(FrameFormat format) {
     frame_format_ = format;
-    reset();
+    reset(false);
   }
   FrameFormat frame_format() const { return frame_format_; }
+  void count_reset() { reset_count_++; }
+  uint32_t consume_reset_count() {
+    const uint32_t count = reset_count_;
+    reset_count_ = 0;
+    return count;
+  }
 
 private:
   void reset_normal_restart_state_() {
@@ -736,6 +744,7 @@ private:
                  static_cast<unsigned>(candidate.marker_index + 1), candidate.header[0], candidate.header[1],
                  candidate.header[2]);
         const std::array<uint8_t, 4> restarted_header = candidate.follow;
+        count_reset();
         reset_frame_state_();
         frame.raw[0] = restarted_header[0];
         frame.raw[1] = restarted_header[1];
@@ -745,7 +754,7 @@ private:
         data_index_ = 4;
         if (!frame.validate_bounds()) {
           ESP_LOGV("READER", "Invalid restarted frame length 0x%02X; resetting reader", frame.data_length);
-          reset();
+          reset(true);
         } else {
           expected_total_ = DATA_OFFSET_FROM_START + frame.data_length + 1;
         }
@@ -913,6 +922,8 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
   void set_antibacteria_switch(switch_::Switch *antibacteria_switch) { antibacteria_switch_ = antibacteria_switch; }
 
   void set_failed_crcs_sensor(sensor::Sensor *failed_crcs_sensor) { this->failed_crcs_sensor_ = failed_crcs_sensor; }
+  void set_reader_reset_rate_sensor(sensor::Sensor *sensor) { this->reader_reset_rate_sensor_ = sensor; }
+  void set_crc_failures_5min_sensor(sensor::Sensor *sensor) { this->crc_failures_5min_sensor_ = sensor; }
 
   void send_command(struct DataFrame command);
   bool send_raw_frame_from_text(const std::string &frame_text);
@@ -1006,6 +1017,8 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
   bool is_own_tx_echo_(const DataFrame *f) const; //used to filter echo after sending frame
   void remember_tx_frame_for_echo_(const uint8_t *bytes, size_t size, bool tu2c);
   void update_frame_validation_();
+  void record_crc_failure_();
+  void publish_reader_diagnostics_();
   bool has_bus_quiet_time_elapsed_(uint32_t now) const;
   bool has_tu2c_quiet_time_elapsed_(uint32_t now) const;
   bool should_auto_detect_frame_format_() const { return frame_format_auto_ && !frame_format_confirmed_; }
@@ -1030,6 +1043,13 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
   switch_::Switch *dhw_boost_switch_{nullptr};
   switch_::Switch *antibacteria_switch_{nullptr};
   sensor::Sensor *failed_crcs_sensor_{nullptr};
+  sensor::Sensor *reader_reset_rate_sensor_{nullptr};
+  sensor::Sensor *crc_failures_5min_sensor_{nullptr};
+  uint32_t crc_failure_count_{0};
+  uint32_t last_diagnostics_publish_ms_{0};
+  static const uint8_t CRC_HISTORY_SIZE = 10;
+  std::array<uint32_t, CRC_HISTORY_SIZE> crc_history_counts_{{0}};
+  uint8_t crc_history_next_{0};
 
   sensor::Sensor *current_sensor_{nullptr}; // Sensor for current, x10 A
 

--- a/components/toshiba_ab/toshiba_ab.h
+++ b/components/toshiba_ab/toshiba_ab.h
@@ -744,7 +744,6 @@ private:
                  static_cast<unsigned>(candidate.marker_index + 1), candidate.header[0], candidate.header[1],
                  candidate.header[2]);
         const std::array<uint8_t, 4> restarted_header = candidate.follow;
-        count_reset();
         reset_frame_state_();
         frame.raw[0] = restarted_header[0];
         frame.raw[1] = restarted_header[1];
@@ -922,7 +921,7 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
   void set_antibacteria_switch(switch_::Switch *antibacteria_switch) { antibacteria_switch_ = antibacteria_switch; }
 
   void set_failed_crcs_sensor(sensor::Sensor *failed_crcs_sensor) { this->failed_crcs_sensor_ = failed_crcs_sensor; }
-  void set_reader_reset_rate_sensor(sensor::Sensor *sensor) { this->reader_reset_rate_sensor_ = sensor; }
+  void set_noise_rate_sensor(sensor::Sensor *sensor) { this->noise_rate_sensor_ = sensor; }
   void set_crc_failures_5min_sensor(sensor::Sensor *sensor) { this->crc_failures_5min_sensor_ = sensor; }
 
   void send_command(struct DataFrame command);
@@ -1043,7 +1042,7 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
   switch_::Switch *dhw_boost_switch_{nullptr};
   switch_::Switch *antibacteria_switch_{nullptr};
   sensor::Sensor *failed_crcs_sensor_{nullptr};
-  sensor::Sensor *reader_reset_rate_sensor_{nullptr};
+  sensor::Sensor *noise_rate_sensor_{nullptr};
   sensor::Sensor *crc_failures_5min_sensor_{nullptr};
   uint32_t crc_failure_count_{0};
   uint32_t last_diagnostics_publish_ms_{0};


### PR DESCRIPTION
### Motivation

- Improve visibility into the Toshiba AB bus reader health by exposing reader reset rate and a rolling 5-minute CRC failure count so users can detect flaky buses or hardware issues.

### Description

- Add two diagnostic sensors to the config schema (`reader_reset_rate` and `crc_failures_5min`) with defaults and auto-create them in `to_code` so they are available without explicit YAML.
- Track reader resets inside `DataFrameReader` by adding `reset(bool count_as_error)`, a `reset_count_` counter, `count_reset()` and `consume_reset_count()`, and switch many error paths to call `reset(true)` so recovery resets are counted.
- Centralize CRC-failure handling with `record_crc_failure_()` and add TU2C checksum validation, updating receive logic to call `record_crc_failure_()` on checksum/CRC problems and to log TU2C failures.
- Publish diagnostics every 30s via `publish_reader_diagnostics_()` which computes resets/min from the reader and aggregates CRC failures into a 5-minute rolling window, and expose setters and member sensors for the new diagnostic sensors.

### Testing

- Built the firmware (component compiled as part of the ESPHome build) and the compilation succeeded.
- No new automated unit tests were added for the component; compilation and basic static checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6fe5bc07c8832facb1e5d21da0419c)