### PR TITLE
Report CRC failure and noise rates in config dump

### DIFF
--- a/components/toshiba_ab/toshiba_ab.cpp
+++ b/components/toshiba_ab/toshiba_ab.cpp
@@ -1265,6 +1265,8 @@ void ToshibaAbClimate::dump_config() {
   ESP_LOGCONFIG(TAG, "  Polled sensors configured: %zu", this->polled_sensors_.size());
   ESP_LOGCONFIG(TAG, "  Connected sensor: %s", this->connected_binary_sensor_ ? "yes" : "no");
   ESP_LOGCONFIG(TAG, "  Failed CRCs sensor: %s", this->failed_crcs_sensor_ ? "yes" : "no");
+  LOG_SENSOR("  ", "Noise Rate", this->noise_rate_sensor_);
+  LOG_SENSOR("  ", "CRC Failure Rate", this->crc_failures_5min_sensor_);
   ESP_LOGCONFIG(TAG, "  Reader diagnostics: enabled (30s updates)");
   ESP_LOGCONFIG(TAG, "  Filter alert sensor: %s", this->filter_alert_sensor_ ? "yes" : "no");
   ESP_LOGCONFIG(TAG, "  Vent switch: %s", this->vent_switch_ ? "yes" : "no");


### PR DESCRIPTION
### Motivation
- Ensure the diagnostic sensors for noise rate and 5-minute CRC failure rate appear in the component configuration dump so their entity metadata is visible in ESPHome logs.

### Description
- Add ESPHome-standard sensor logging lines in `ToshibaAbClimate::dump_config()` to log the Noise Rate and CRC Failure Rate via `LOG_SENSOR` in `components/toshiba_ab/toshiba_ab.cpp`.

### Testing
- Ran `python3 -m py_compile components/toshiba_ab/climate.py` and `git diff --check` (both succeeded) and ran `clang-format --dry-run --Werror components/toshiba_ab/toshiba_ab.cpp` which failed due to preexisting formatting differences in the source file unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6fecf53cd4832fb203d45c909bfe1d)