### PR TITLE
Block outbound frames during initial 30s after boot

### DIFF
--- a/components/toshiba_ab/toshiba_ab.cpp
+++ b/components/toshiba_ab/toshiba_ab.cpp
@@ -307,6 +307,10 @@ bool ToshibaAbClimate::has_bus_quiet_time_elapsed_(uint32_t now) const {
          (now - this->last_sent_frame_millis_) >= FRAME_SEND_MILLIS_FROM_LAST_SEND;
 }
 
+bool ToshibaAbClimate::is_initial_frame_send_block_active_(uint32_t now) const {
+  return (now - this->boot_millis_) < INITIAL_FRAME_SEND_BLOCK_MILLIS;
+}
+
 bool ToshibaAbClimate::has_tu2c_quiet_time_elapsed_(uint32_t now) const {
   return (now - this->last_tu2c_received_frame_millis_) >= TU2C_FRAME_SEND_MILLIS_FROM_LAST_RECEIVE &&
          (now - this->last_tu2c_sent_frame_millis_) >= TU2C_FRAME_SEND_MILLIS_FROM_LAST_SEND;
@@ -1271,6 +1275,7 @@ void ToshibaAbClimate::dump_config() {
 }
 
 void ToshibaAbClimate::setup() {
+  this->boot_millis_ = millis();
   if (this->failed_crcs_sensor_ != nullptr) {
     this->failed_crcs_sensor_->publish_state(0);
   }
@@ -2533,13 +2538,21 @@ void ToshibaAbClimate::loop() {
   // TODO: check if last_unconfirmed_command_ was not confirmed after a timeout
   // and log warning/error
 
+  const uint32_t now = millis();
+  const bool initial_send_block_active = this->is_initial_frame_send_block_active_(now);
+  if (initial_send_block_active && !this->initial_frame_send_block_logged_) {
+    ESP_LOGI(TAG, "Blocking outbound frames for the first %" PRIu32 "ms after boot", INITIAL_FRAME_SEND_BLOCK_MILLIS);
+    this->initial_frame_send_block_logged_ = true;
+  }
+
   // Drain the pending sensor-query queue at most one per loop iteration.
   // This must run BEFORE the TX dispatch below so an enqueued 0x17 has a
   // chance to be picked up in the same tick.
-  this->drain_sensor_query_queue_();
+  if (!initial_send_block_active) {
+    this->drain_sensor_query_queue_();
+  }
 
-  const uint32_t now = millis();
-  const bool bus_can_send = this->has_bus_quiet_time_elapsed_(now);
+  const bool bus_can_send = !initial_send_block_active && this->has_bus_quiet_time_elapsed_(now);
 
   if (bus_can_send) {
     optional<DataFrame> frame_to_send{};
@@ -2675,7 +2688,7 @@ void ToshibaAbClimate::loop() {
   }
 
   // Estia command ACK timeout and retry
-  if (!estia_pending_cmd_.empty() && (millis() - estia_cmd_sent_ms_) > ESTIA_CMD_ACK_TIMEOUT_MS) {
+  if (!initial_send_block_active && !estia_pending_cmd_.empty() && (millis() - estia_cmd_sent_ms_) > ESTIA_CMD_ACK_TIMEOUT_MS) {
     if (estia_cmd_attempts_ >= ESTIA_MAX_CMD_ATTEMPTS) {
       ESP_LOGW(TAG, "Command not acknowledged after %u attempts (dtype %02X:%02X)",
                estia_cmd_attempts_,

--- a/components/toshiba_ab/toshiba_ab.h
+++ b/components/toshiba_ab/toshiba_ab.h
@@ -20,6 +20,7 @@ const uint32_t LAST_ALIVE_TIMEOUT_MILLIS = ALIVE_MESSAGE_PERIOD_MILLIS * 3 +1000
 const uint32_t PACKET_MIN_WAIT_MILLIS = 200;
 const uint32_t FRAME_SEND_MILLIS_FROM_LAST_RECEIVE = 500;
 const uint32_t FRAME_SEND_MILLIS_FROM_LAST_SEND = 500;
+const uint32_t INITIAL_FRAME_SEND_BLOCK_MILLIS = 30000;
 
 // const uint8_t TOSHIBA_MASTER = 0x00;  replaced by master_address_ which is set up in yaml
 const uint8_t TOSHIBA_MASTER_DEFAULT = 0x00;
@@ -1018,6 +1019,7 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
   void update_frame_validation_();
   void record_crc_failure_();
   void publish_reader_diagnostics_();
+  bool is_initial_frame_send_block_active_(uint32_t now) const;
   bool has_bus_quiet_time_elapsed_(uint32_t now) const;
   bool has_tu2c_quiet_time_elapsed_(uint32_t now) const;
   bool should_auto_detect_frame_format_() const { return frame_format_auto_ && !frame_format_confirmed_; }
@@ -1142,6 +1144,8 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
 
   uint32_t last_received_frame_millis_ = 0;
   uint32_t last_sent_frame_millis_ = 0;
+  uint32_t boot_millis_{0};
+  bool initial_frame_send_block_logged_{false};
   uint32_t last_tu2c_received_frame_millis_ = 0;
   uint32_t last_tu2c_sent_frame_millis_ = 0;
   std::queue<DataFrame> write_queue_;


### PR DESCRIPTION
### Motivation
- Avoid the component transmitting frames immediately after power-up so it does not send commands while the bus and master unit are still being detected and the component is initializing.

### Description
- Add `INITIAL_FRAME_SEND_BLOCK_MILLIS = 30000` and new member state `boot_millis_` and `initial_frame_send_block_logged_` to track boot time and a one-time log flag.
- Implement `is_initial_frame_send_block_active_(uint32_t now)` and set `boot_millis_ = millis()` in `setup()` to mark the start of the block window.
- Gate `loop()` behavior while the block is active by skipping `drain_sensor_query_queue_()`, preventing TX dispatch (`bus_can_send` is false while active), and deferring Estia ACK retry handling until the block expires, while logging the block start once.

### Testing
- Ran `git diff --check` which produced no issues (success).  
- Ran `./format.sh` which failed due to unrelated/missing files referenced by the formatting script (warning).  
- Attempted `platformio run` which could not run in this environment because `platformio` is not installed (not executed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7275672b18832fa201e6350b02932a)