### PR TITLE
toshiba_ab: publish bus inventory and add text sensors for discovered units/remotes

### DIFF
--- a/components/toshiba_ab/climate.py
+++ b/components/toshiba_ab/climate.py
@@ -30,7 +30,7 @@ from esphome.const import (
 from esphome.core import CORE
 
 DEPENDENCIES = ["uart"]
-AUTO_LOAD = ["climate", "binary_sensor", "sensor", "switch"]
+AUTO_LOAD = ["climate", "binary_sensor", "sensor", "switch", "text_sensor"]
 CODEOWNERS = ["@muxa"]
 
 toshiba_ab_ns = cg.esphome_ns.namespace("toshiba_ab")
@@ -41,6 +41,10 @@ CONF_READ_ONLY_SWITCH = "read_only_switch"
 CONF_FAILED_CRCS = "failed_crcs"
 CONF_NOISE_RATE = "noise_rate"
 CONF_CRC_FAILURES_5MIN = "crc_failures_5min"
+CONF_INDOOR_UNIT_COUNT = "indoor_unit_count"
+CONF_INDOOR_UNITS = "indoor_units"
+CONF_REMOTE_COUNT = "remote_count"
+CONF_REMOTE_ADDRESSES = "remote_addresses"
 
 CONF_ON_DATA_RECEIVED = "on_data_received"
 CONF_MASTER = "master"
@@ -293,6 +297,18 @@ CONFIG_SCHEMA = climate._CLIMATE_SCHEMA.extend(
             entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
             state_class=STATE_CLASS_MEASUREMENT,
         ),
+        cv.Optional(CONF_INDOOR_UNIT_COUNT, default={"name": "Toshiba Indoor Unit Count"}): text_sensor.text_sensor_schema(
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        ),
+        cv.Optional(CONF_INDOOR_UNITS, default={"name": "Toshiba Indoor Units"}): text_sensor.text_sensor_schema(
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        ),
+        cv.Optional(CONF_REMOTE_COUNT, default={"name": "Toshiba Remote Count"}): text_sensor.text_sensor_schema(
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        ),
+        cv.Optional(CONF_REMOTE_ADDRESSES, default={"name": "Toshiba Remote Addresses"}): text_sensor.text_sensor_schema(
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        ),
         cv.Optional(CONF_ON_DATA_RECEIVED): automation.validate_automation(
             {
                cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(ToshibaAbOnDataReceivedTrigger),
@@ -454,6 +470,14 @@ async def to_code(config):
     cg.add(var.set_noise_rate_sensor(noise_rate))
     crc_rate = await sensor.new_sensor(config[CONF_CRC_FAILURES_5MIN])
     cg.add(var.set_crc_failures_5min_sensor(crc_rate))
+    indoor_count = await text_sensor.new_text_sensor(config[CONF_INDOOR_UNIT_COUNT])
+    cg.add(var.set_indoor_unit_count_text_sensor(indoor_count))
+    indoor_units = await text_sensor.new_text_sensor(config[CONF_INDOOR_UNITS])
+    cg.add(var.set_indoor_units_text_sensor(indoor_units))
+    remote_count = await text_sensor.new_text_sensor(config[CONF_REMOTE_COUNT])
+    cg.add(var.set_remote_count_text_sensor(remote_count))
+    remote_addresses = await text_sensor.new_text_sensor(config[CONF_REMOTE_ADDRESSES])
+    cg.add(var.set_remote_addresses_text_sensor(remote_addresses))
 
     if CONF_VENT in config:
         sw = await switch.new_switch(config[CONF_VENT], var)

--- a/components/toshiba_ab/toshiba_ab.cpp
+++ b/components/toshiba_ab/toshiba_ab.cpp
@@ -1473,6 +1473,7 @@ void ToshibaAbClimate::setup() {
   }
 
   this->update_frame_validation_();
+  this->publish_bus_inventory_();
 
     // next block manages the temp reporting to the central unit using the external sensor approach if configured,
     // this sends a different temp frame to the one sent with the ping above,
@@ -1652,6 +1653,7 @@ void ToshibaAbClimate::process_received_data(const struct DataFrame *frame) {
       switch (frame->opcode1) {
         case OPCODE_PING: {
         log_data_frame("PING/ALIVE", frame);
+        this->record_discovered_address_(frame->source, false);
         this->confirm_frame_format_(FrameFormat::NORMAL, "valid keepalive from master");
         break;
         }
@@ -1840,6 +1842,7 @@ void ToshibaAbClimate::process_received_data(const struct DataFrame *frame) {
                 frame->data[1] == OPCODE2_PING_PONG &&         // 0x0C
                 frame->data[2] == OPCODE2_READ_STATUS) {       // 0x81
         log_data_frame("Remote PING", frame);
+        this->record_discovered_address_(frame->source, true);
         
         // Auto-update master address if enabled and different from current
         if (this->master_address_auto_ &&
@@ -1953,6 +1956,7 @@ void ToshibaAbClimate::process_received_data_tu2c_(const struct DataFrame *frame
   if (frame_length == 0x0A && has_tail_signature) {
     log_raw_data("Master keepalive", frame->raw, size);
     ESP_LOGD(TAG, "Master %02X keepalive", source);
+    this->record_discovered_address_(source, false);
     last_master_alive_millis_ = millis();
     if (this->connected_binary_sensor_) {
       this->connected_binary_sensor_->publish_state(true);
@@ -1984,6 +1988,7 @@ void ToshibaAbClimate::process_received_data_tu2c_(const struct DataFrame *frame
       frame->raw[payload_offset + 1] == 0x5C) {
     log_raw_data("Remote keepalive frame", frame->raw, size);
     ESP_LOGD(TAG, "Remote %02X keepalive", source);
+    this->record_discovered_address_(source, true);
     return;
   }
 
@@ -2529,6 +2534,45 @@ bool ToshibaAbClimate::receive_data_frame(const struct DataFrame *frame) {
     process_received_data(frame);
   }
   return true;
+}
+
+void ToshibaAbClimate::record_discovered_address_(uint8_t address, bool remote) {
+  if (millis() > BUS_DISCOVERY_PERIOD_MILLIS) return;
+  std::bitset<256> &addresses = remote ? this->discovered_remotes_ : this->discovered_indoor_units_;
+  if (addresses.test(address)) return;
+
+  addresses.set(address);
+  ESP_LOGI(TAG, "Discovered %s keepalive address 0x%02X", remote ? "remote" : "indoor unit", address);
+  this->publish_bus_inventory_();
+}
+
+void ToshibaAbClimate::publish_bus_inventory_() {
+  if (this->indoor_unit_count_text_sensor_ != nullptr)
+    this->indoor_unit_count_text_sensor_->publish_state(std::to_string(this->discovered_indoor_units_.count()));
+  if (this->remote_count_text_sensor_ != nullptr)
+    this->remote_count_text_sensor_->publish_state(std::to_string(this->discovered_remotes_.count()));
+
+  std::string indoor_units;
+  std::string remote_addresses;
+  char address[8];
+  for (size_t i = 0; i < 256; i++) {
+    if (this->discovered_indoor_units_.test(i)) {
+      std::snprintf(address, sizeof(address), "0x%02X", static_cast<unsigned>(i));
+      if (!indoor_units.empty()) indoor_units += ", ";
+      indoor_units += address;
+      indoor_units += " (indoor unit)";
+    }
+    if (this->discovered_remotes_.test(i)) {
+      std::snprintf(address, sizeof(address), "0x%02X", static_cast<unsigned>(i));
+      if (!remote_addresses.empty()) remote_addresses += ", ";
+      remote_addresses += address;
+    }
+  }
+  if (indoor_units.empty()) indoor_units = "None detected";
+  if (remote_addresses.empty()) remote_addresses = "None detected";
+  if (this->indoor_units_text_sensor_ != nullptr) this->indoor_units_text_sensor_->publish_state(indoor_units);
+  if (this->remote_addresses_text_sensor_ != nullptr)
+    this->remote_addresses_text_sensor_->publish_state(remote_addresses);
 }
 
 
@@ -3592,6 +3636,9 @@ void ToshibaAbClimate::process_received_data_estia_first_gen_(const DataFrame *f
     ESP_LOGD(TAG, "Estia first-gen checksum fail for %s", label.c_str());
     return;
   }
+  if (has_master_keepalive_signature && is_possible_master_source)
+    this->record_discovered_address_(src, false);
+  if (has_remote_ping_signature && is_remote_source) this->record_discovered_address_(src, true);
   if (has_master_keepalive_signature && is_possible_master_source) {
     if (this->master_address_auto_ && !this->master_address_confirmed_ && src != this->master_address_) {
       ESP_LOGI(TAG, "Estia first-gen master keepalive from 0x%02X; switching master address from 0x%02X",

--- a/components/toshiba_ab/toshiba_ab.h
+++ b/components/toshiba_ab/toshiba_ab.h
@@ -4,6 +4,7 @@
 #include "esphome/components/climate/climate.h"
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/switch/switch.h"
+#include "esphome/components/text_sensor/text_sensor.h"
 #include "esphome/components/uart/uart.h"
 #include <algorithm>
 #include <array>
@@ -21,6 +22,7 @@ const uint32_t PACKET_MIN_WAIT_MILLIS = 200;
 const uint32_t FRAME_SEND_MILLIS_FROM_LAST_RECEIVE = 500;
 const uint32_t FRAME_SEND_MILLIS_FROM_LAST_SEND = 500;
 const uint32_t INITIAL_FRAME_SEND_BLOCK_MILLIS = 30000;
+const uint32_t BUS_DISCOVERY_PERIOD_MILLIS = 180000;
 
 // const uint8_t TOSHIBA_MASTER = 0x00;  replaced by master_address_ which is set up in yaml
 const uint8_t TOSHIBA_MASTER_DEFAULT = 0x00;
@@ -922,6 +924,10 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
   void set_failed_crcs_sensor(sensor::Sensor *failed_crcs_sensor) { this->failed_crcs_sensor_ = failed_crcs_sensor; }
   void set_noise_rate_sensor(sensor::Sensor *sensor) { this->noise_rate_sensor_ = sensor; }
   void set_crc_failures_5min_sensor(sensor::Sensor *sensor) { this->crc_failures_5min_sensor_ = sensor; }
+  void set_indoor_unit_count_text_sensor(text_sensor::TextSensor *sensor) { this->indoor_unit_count_text_sensor_ = sensor; }
+  void set_indoor_units_text_sensor(text_sensor::TextSensor *sensor) { this->indoor_units_text_sensor_ = sensor; }
+  void set_remote_count_text_sensor(text_sensor::TextSensor *sensor) { this->remote_count_text_sensor_ = sensor; }
+  void set_remote_addresses_text_sensor(text_sensor::TextSensor *sensor) { this->remote_addresses_text_sensor_ = sensor; }
 
   void send_command(struct DataFrame command);
   bool send_raw_frame_from_text(const std::string &frame_text);
@@ -1020,6 +1026,8 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
   void update_frame_validation_();
   void record_crc_failure_();
   void publish_reader_diagnostics_();
+  void record_discovered_address_(uint8_t address, bool remote);
+  void publish_bus_inventory_();
   bool is_initial_frame_send_block_active_(uint32_t now) const;
   bool has_bus_quiet_time_elapsed_(uint32_t now) const;
   bool has_tu2c_quiet_time_elapsed_(uint32_t now) const;
@@ -1047,6 +1055,12 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
   sensor::Sensor *failed_crcs_sensor_{nullptr};
   sensor::Sensor *noise_rate_sensor_{nullptr};
   sensor::Sensor *crc_failures_5min_sensor_{nullptr};
+  text_sensor::TextSensor *indoor_unit_count_text_sensor_{nullptr};
+  text_sensor::TextSensor *indoor_units_text_sensor_{nullptr};
+  text_sensor::TextSensor *remote_count_text_sensor_{nullptr};
+  text_sensor::TextSensor *remote_addresses_text_sensor_{nullptr};
+  std::bitset<256> discovered_indoor_units_{};
+  std::bitset<256> discovered_remotes_{};
   uint32_t crc_failure_count_{0};
   uint32_t last_diagnostics_publish_ms_{0};
   static const uint8_t CRC_HISTORY_SIZE = 10;


### PR DESCRIPTION
### Motivation

- Provide visibility into devices seen on the TCC/TU2C bus by tracking discovered indoor unit and remote addresses during an initial discovery window.
- Surface diagnostics via Home Assistant by exposing counts and comma-separated address lists as `text_sensor`s to aid troubleshooting and auto-detection of master/remotes.

### Description

- Added new configuration keys and schemas `CONF_INDOOR_UNIT_COUNT`, `CONF_INDOOR_UNITS`, `CONF_REMOTE_COUNT`, and `CONF_REMOTE_ADDRESSES` and included `text_sensor` in `AUTO_LOAD` and imports.
- Created text sensors in `to_code` and added corresponding setter methods and members in `toshiba_ab.h` (`indoor_*` and `remote_*` text sensors and `discovered_indoor_units_`/`discovered_remotes_` bitsets).
- Implemented bus discovery logic with `BUS_DISCOVERY_PERIOD_MILLIS`, `record_discovered_address_()` to record addresses seen during discovery, and `publish_bus_inventory_()` to publish counts and readable address lists to the `text_sensor`s.
- Hooked address recording into multiple frame-processing paths (`process_received_data`, `process_received_data_tu2c_`, and `process_received_data_estia_first_gen_`) and invoked `publish_bus_inventory_()` during setup to surface initial state.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a73c46c9b44832faa4d011f3708db1d)