### PR TITLE
Add GitHub issue forms for hardware and software reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: false
+

--- a/.github/ISSUE_TEMPLATE/hardware-issue.yml
+++ b/.github/ISSUE_TEMPLATE/hardware-issue.yml
@@ -1,0 +1,69 @@
+name: Hardware issue
+description: Report a problem with the interface board or its installation.
+title: "[Hardware]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a hardware issue. Please provide the details below so we can help diagnose it.
+
+  - type: dropdown
+    id: board
+    attributes:
+      label: Board type
+      description: Which interface board are you using?
+      options:
+        - v3.2
+        - D1 mini
+        - Other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: machine
+    attributes:
+      label: Machine type
+      description: What kind of system is the board connected to?
+      options:
+        - Air-to-air
+        - Hydronic
+    validations:
+      required: true
+
+  - type: input
+    id: model
+    attributes:
+      label: Model number
+      description: Enter the model number of the connected machine, if known.
+      placeholder: e.g. RAS-B10N4KVRG-E
+
+  - type: dropdown
+    id: protocol
+    attributes:
+      label: Protocol used
+      description: Select the configured or detected protocol.
+      options:
+        - TCC-Link
+        - HM
+        - TU2C
+        - Estia A0
+        - Estia first-generation
+        - Unknown
+    validations:
+      required: true
+
+  - type: textarea
+    id: installation-photos
+    attributes:
+      label: Installation photos
+      description: Drag and drop photos here showing the board, wiring, and its connection to the machine. Remove any sensitive information before uploading.
+      placeholder: Drag and drop installation photos here.
+
+  - type: textarea
+    id: details
+    attributes:
+      label: Issue details
+      description: Describe the problem, what you expected, and any troubleshooting already attempted.
+    validations:
+      required: true
+

--- a/.github/ISSUE_TEMPLATE/software-issue.yml
+++ b/.github/ISSUE_TEMPLATE/software-issue.yml
@@ -1,0 +1,69 @@
+name: Software issue
+description: Report a problem with the component software or configuration.
+title: "[Software]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a software issue. Please provide the details below so we can help diagnose it.
+
+  - type: dropdown
+    id: board
+    attributes:
+      label: Board type
+      description: Which interface board are you using?
+      options:
+        - v3.2
+        - D1 mini
+        - Other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: machine
+    attributes:
+      label: Machine type
+      description: What kind of system is the board connected to?
+      options:
+        - Air-to-air
+        - Hydronic
+    validations:
+      required: true
+
+  - type: input
+    id: model
+    attributes:
+      label: Model number
+      description: Enter the model number of the connected machine, if known.
+      placeholder: e.g. RAS-B10N4KVRG-E
+
+  - type: dropdown
+    id: protocol
+    attributes:
+      label: Protocol used
+      description: Select the configured or detected protocol.
+      options:
+        - TCC-Link
+        - HM
+        - TU2C
+        - Estia A0
+        - Estia first-generation
+        - Unknown
+    validations:
+      required: true
+
+  - type: textarea
+    id: installation-photos
+    attributes:
+      label: Installation photos
+      description: Drag and drop photos here showing the board, wiring, and its connection to the machine. Remove any sensitive information before uploading.
+      placeholder: Drag and drop installation photos here.
+
+  - type: textarea
+    id: details
+    attributes:
+      label: Issue details
+      description: Describe the problem, what you expected, and any troubleshooting already attempted.
+    validations:
+      required: true
+


### PR DESCRIPTION
### Motivation

- Provide a required, structured way for users to open issues by offering forms for hardware and software reports and preventing blank issues.
- Capture consistent diagnostic data (board, machine type, model, protocol, photos, and details) to speed triage and reduce back-and-forth.

### Description

- Disable blank issues by adding `.github/ISSUE_TEMPLATE/config.yml` with `blank_issues_enabled: false`.
- Add a hardware issue form at `.github/ISSUE_TEMPLATE/hardware-issue.yml` that requires `board`, `machine`, and `protocol` and includes `model`, `installation-photos`, and a required `details` field.
- Add a software issue form at `.github/ISSUE_TEMPLATE/software-issue.yml` that mirrors the hardware form fields for initial parity and later refinement.
- Ensure the `protocol` dropdown includes an `Unknown` option and provide helpful labels/descriptions for photo uploads and model hints.

### Testing

- Ran `ruby -e 'require "yaml"; Dir[".github/ISSUE_TEMPLATE/*.{yml,yaml}"].each { |f| YAML.safe_load_file(f); puts "valid YAML: #{f}" }'` to validate YAML parsing, which succeeded.
- Executed a Ruby assertion script that checked required form `id`s and that `protocol` contains `Unknown`, and it passed (`issue-form structure checks passed`).
- Ran `git diff --check` to validate no whitespace/diff issues, which returned no problems.
- Invoked the local `make_pr` MCP tool to generate PR metadata via `make_pr` over stdio and received the structured PR response, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8040464640832fbc1e5dc9b9000b89)