### PR TITLE
Log Estia A0 frames at DEBUG and correct SRC/DST parsing

### DIFF
--- a/components/toshiba_ab/toshiba_ab.cpp
+++ b/components/toshiba_ab/toshiba_ab.cpp
@@ -489,6 +489,21 @@ void log_raw_data(const std::string& prefix, const uint8_t raw[], size_t size) {
   ESP_LOGV("RX", "%s: %s", prefix.c_str(), res.c_str());
 }
 
+void log_estia_data_frame(const std::string &msg, const struct DataFrame *frame) {
+  if (frame == nullptr) return;
+
+  const size_t size = frame->estia_size();
+  std::string res = "A0:00";
+  res.reserve(5 + (size ? size * 3 : 0));
+  char buf[3];
+  for (size_t i = 0; i < size; i++) {
+    std::snprintf(buf, sizeof(buf), "%02X", frame->raw[i]);
+    res += ':';
+    res += buf;
+  }
+  ESP_LOGD("RX", "%s: %s", msg.c_str(), res.c_str());
+}
+
 std::string frame_to_hex_string(const DataFrame *frame) {
   if (frame == nullptr) {
     return "";
@@ -2085,21 +2100,24 @@ bool ToshibaAbClimate::receive_data_frame(const struct DataFrame *frame) {
           case 0x55: type_name = "STATUS_SHORT"; break;
           case 0x58: type_name = "STATUS"; break;
         }
-        uint16_t src = (fsz > 4) ? ((frame->raw[3] << 8) | frame->raw[4]) : 0;
-        uint16_t dst = (fsz > 6) ? ((frame->raw[5] << 8) | frame->raw[6]) : 0;
+        uint8_t src_mode = (fsz > 4) ? frame->raw[3] : 0;
+        uint8_t src = (fsz > 4) ? frame->raw[4] : 0;
+        uint8_t dst_mode = (fsz > 6) ? frame->raw[5] : 0;
+        uint8_t dst = (fsz > 6) ? frame->raw[6] : 0;
         const char *src_name = "???";
-        if (src == 0x0800) src_name = "MASTER";
-        else if (src == 0x0040) src_name = "REMOTE";
-        else if (src == 0x0041) src_name = "0-10V";
-        else if (src == 0x0390) src_name = "KNX-GW";
+        if (src_mode == 0x08 && src == 0x00) src_name = "MASTER";
+        else if (src == 0x40) src_name = "REMOTE";
+        else if (src == 0x41) src_name = "0-10V";
+        else if (src == 0x90) src_name = "KNX-GW";
         const char *dst_name = "???";
-        if (dst == 0x0800) dst_name = "MASTER";
-        else if (dst == 0x0040) dst_name = "REMOTE";
-        else if (dst == 0x0041) dst_name = "0-10V";
-        else if (dst == 0x00FE) dst_name = "BROADCAST";
-        else if (dst == 0x0390) dst_name = "KNX-GW";
-        ESP_LOGD(TAG, "  type=0x%02X(%s) len=%u src=0x%04X(%s) dst=0x%04X(%s)",
-                 ft, type_name, fl, src, src_name, dst, dst_name);
+        if (dst_mode == 0x08 && dst == 0x00) dst_name = "MASTER";
+        else if (dst == 0x40) dst_name = "REMOTE";
+        else if (dst == 0x41) dst_name = "0-10V";
+        else if (dst == 0xFE) dst_name = "BROADCAST";
+        else if (dst == 0x90) dst_name = "KNX-GW";
+        ESP_LOGD(TAG, "  type=0x%02X(%s) len=%u src_mode=0x%02X src=0x%02X(%s) "
+                      "dst_mode=0x%02X dst=0x%02X(%s)",
+                 ft, type_name, fl, src_mode, src, src_name, dst_mode, dst, dst_name);
         if (fsz > 8) {
           ESP_LOGD(TAG, "  dtype=%02X:%02X", frame->raw[7], frame->raw[8]);
         }
@@ -2109,30 +2127,32 @@ bool ToshibaAbClimate::receive_data_frame(const struct DataFrame *frame) {
     }
     uint8_t frame_type = frame->raw[0];
     uint8_t frame_len = frame->raw[1];
-    ESP_LOGV(TAG, "RX frame: type=0x%02X len=%d src=0x%02X%02X dst=0x%02X%02X",
+    log_estia_data_frame("Estia frame", frame);
+    ESP_LOGV(TAG, "RX frame: type=0x%02X len=%d src_mode=0x%02X src=0x%02X dst_mode=0x%02X dst=0x%02X",
              frame_type, frame_len,
              frame->raw[3], frame->raw[4],
              frame->raw[5], frame->raw[6]);
-    log_raw_data("Estia", frame->raw, fsz);
 
     // Verbose decode of all Estia frames
     {
-      uint16_t src_addr = (frame->raw[3] << 8) | frame->raw[4];
-      uint16_t dst_addr = (frame->raw[5] << 8) | frame->raw[6];
+      uint8_t src_mode = frame->raw[3];
+      uint8_t src_addr = frame->raw[4];
+      uint8_t dst_mode = frame->raw[5];
+      uint8_t dst_addr = frame->raw[6];
       uint16_t dtype = (frame_len >= 7) ? ((frame->raw[7] << 8) | frame->raw[8]) : 0;
 
       const char *src_name = "???";
-      if (src_addr == 0x0800) src_name = "MASTER";
-      else if (src_addr == 0x0040) src_name = "REMOTE";
-      else if (src_addr == 0x0041) src_name = "0-10V";
-      else if (src_addr == 0x0390) src_name = "KNX-GW";
+      if (src_mode == 0x08 && src_addr == 0x00) src_name = "MASTER";
+      else if (src_addr == 0x40) src_name = "REMOTE";
+      else if (src_addr == 0x41) src_name = "0-10V";
+      else if (src_addr == 0x90) src_name = "KNX-GW";
 
       const char *dst_name = "???";
-      if (dst_addr == 0x0800) dst_name = "MASTER";
-      else if (dst_addr == 0x0040) dst_name = "REMOTE";
-      else if (dst_addr == 0x0041) dst_name = "0-10V";
-      else if (dst_addr == 0x00FE) dst_name = "BROADCAST";
-      else if (dst_addr == 0x0390) dst_name = "KNX-GW";
+      if (dst_mode == 0x08 && dst_addr == 0x00) dst_name = "MASTER";
+      else if (dst_addr == 0x40) dst_name = "REMOTE";
+      else if (dst_addr == 0x41) dst_name = "0-10V";
+      else if (dst_addr == 0xFE) dst_name = "BROADCAST";
+      else if (dst_addr == 0x90) dst_name = "KNX-GW";
 
       const char *type_name = "???";
       switch (frame_type) {
@@ -2145,8 +2165,8 @@ bool ToshibaAbClimate::receive_data_frame(const struct DataFrame *frame) {
         case 0x58: type_name = "STATUS"; break;
       }
 
-      ESP_LOGV(TAG, "  %s(0x%02X) %s(0x%04X)->%s(0x%04X) dtype=%02X:%02X",
-               type_name, frame_type, src_name, src_addr, dst_name, dst_addr,
+      ESP_LOGV(TAG, "  %s(0x%02X) %s(mode=0x%02X addr=0x%02X)->%s(mode=0x%02X addr=0x%02X) dtype=%02X:%02X",
+               type_name, frame_type, src_name, src_mode, src_addr, dst_name, dst_mode, dst_addr,
                frame->raw[7], frame->raw[8]);
 
       // Decode known dtype payloads

--- a/docs/frame_formats.md
+++ b/docs/frame_formats.md
@@ -183,7 +183,10 @@ A full frame looks like:
 A0:00:TYPE:LEN:00:SRC_MODE:SRC:DST_MODE:DST:DTYPE_H:DTYPE_L:DATA...:CRC_H:CRC_L
 ```
 
-`SRC_MODE:SRC` and `DST_MODE:DST` are also referred as `SRC_H:SRC_L` and `DST_H:DST_L` 
+`SRC_MODE:SRC` and `DST_MODE:DST` are pairs of one mode byte and one address
+byte. They are not two-byte source and destination addresses. For example,
+`08:00` means mode `0x08`, master address `0x00`; it does not mean address
+`0x0800`.
 
 The component processes bytes after the `A0:00` prefix. `LEN` is the
 number of bytes between `LEN` and the two-byte CRC. The CRC is CRC-16/MCRF4XX
@@ -199,13 +202,13 @@ Example frames:
 A0:00:11:08:00:00:40:08:00:00:41:22:<CRC_H>:<CRC_L>  # power-off command
 A0:00:11:08:00:00:40:08:00:03:C0:02:<CRC_H>:<CRC_L>  # mode command (heat)
 A0:00:15:0A:00:00:40:08:00:00:E8:C0:01:00:<CRC_H>:<CRC_L>  # data request
-A0:00:18:26:00:SRC_H:SRC_L:DST_H:DST_L:00:E8:C1:01:00:DATA...:CRC_H:CRC_L
+A0:00:18:26:00:SRC_MODE:SRC:DST_MODE:DST:00:E8:C1:01:00:DATA...:CRC_H:CRC_L
 ```
 
 ### Auto-detection
 
 Yes. In `auto` mode, the component watches the byte stream for a complete
-`A0:00` frame with a valid CRC-16 and master source address `0x0800`; it then
+`A0:00` frame with a valid CRC-16 and master source pair `08:00`; it then
 confirms `frame_format: a0`. Because Estia installs often need Estia-specific
 options too, the Estia example forces `a0`.
 


### PR DESCRIPTION
### Motivation

- Make Estia A0 logging consistent with other protocols by ensuring received frames are visible at `DEBUG` level while keeping detailed decoding at `VERBOSE`.
- Avoid overly verbose `VERBOSE` output for routine frame listing but retain detailed payload decoding when needed.
- Clarify and fix the incorrect presentation of SRC/DST as two-byte addresses where the protocol actually uses `MODE:ADDRESS` pairs.

### Description

- Add `log_estia_data_frame()` in `components/toshiba_ab/toshiba_ab.cpp` to reconstruct and log the full wire representation (including the `A0:00` prefix) at `DEBUG` for every valid received Estia A0 frame.
- Replace prior raw logging in the Estia receive path with `log_estia_data_frame()` and adjust the `ESP_LOGV` format to show `src_mode`, `src` and `dst_mode`, `dst` separately rather than a combined 16-bit value.
- Update CRC-failure diagnostic code to parse and report `src_mode/src` and `dst_mode/dst` fields individually and log the reconstructed raw frame consistently.
- Update documentation `docs/frame_formats.md` to explicitly state that `SRC_MODE:SRC` and `DST_MODE:DST` are a one-byte mode plus a one-byte address (e.g. `08:00` = mode `0x08`, address `0x00`) and adjust example frames accordingly.

### Testing

- Ran `git diff --check` to validate there are no whitespace or trivial diff issues, and it succeeded.
- Verified repository state with `git status --short --branch` and `git log -1 --oneline` to confirm changes are present; these commands completed successfully.
- Performed local diffs (`git diff`) and inspected modified files (`components/toshiba_ab/toshiba_ab.cpp`, `docs/frame_formats.md`) to review changes; no automated build or runtime tests were executed in this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a80547cf0e0832f82b98ff05d111372)