### PR TITLE
Fix diagnostic sensor member name collision

### DIFF
--- a/components/toshiba_ab/toshiba_ab.cpp
+++ b/components/toshiba_ab/toshiba_ab.cpp
@@ -315,8 +315,8 @@ void ToshibaAbClimate::diagnostic_(const std::string &message) {
     }
     diagnostic_history_.erase(0, newline + 1);
   }
-  if (diagnostic_ != nullptr)
-    diagnostic_->publish_state(diagnostic_history_);
+  if (diagnostic_sensor_ != nullptr)
+    diagnostic_sensor_->publish_state(diagnostic_history_);
 }
 
 const char *ToshibaAbClimate::protocol_name_(Protocol protocol) {

--- a/components/toshiba_ab/toshiba_ab.h
+++ b/components/toshiba_ab/toshiba_ab.h
@@ -41,7 +41,7 @@ class ToshibaAbClimate : public climate::Climate, public uart::UARTDevice, publi
   void set_esp_address(uint8_t address) { esp_address_ = address; }
   void set_protocol(Protocol protocol) { protocol_setting_ = protocol; }
   void set_system_type(SystemType type) { system_type_ = type; }
-  void set_diagnostic_sensor(text_sensor::TextSensor *sensor) { diagnostic_ = sensor; }
+  void set_diagnostic_sensor(text_sensor::TextSensor *sensor) { diagnostic_sensor_ = sensor; }
   void set_hardware_uart_rx_pin(uint8_t pin) { hardware_uart_rx_pin_ = pin; }
 
  protected:
@@ -88,7 +88,7 @@ class ToshibaAbClimate : public climate::Climate, public uart::UARTDevice, publi
   uint32_t last_byte_ms_{0};
   uint32_t reader_reset_count_{0};
   std::string diagnostic_history_;
-  text_sensor::TextSensor *diagnostic_{nullptr};
+  text_sensor::TextSensor *diagnostic_sensor_{nullptr};
   uint8_t hardware_uart_rx_pin_{0xFF};
 
   std::array<uint8_t, MAX_FRAME_SIZE> tcc_{};


### PR DESCRIPTION
### Motivation
- Avoid a C++ name collision that caused compilation errors by separating the diagnostic text-sensor pointer from the `diagnostic_(const std::string&)` logging method.

### Description
- Rename the member pointer `diagnostic_` to `diagnostic_sensor_` and update the `set_diagnostic_sensor` assignment and the `diagnostic_` method's publish call in `components/toshiba_ab/toshiba_ab.h` and `components/toshiba_ab/toshiba_ab.cpp` to use `diagnostic_sensor_`.

### Testing
- Ran `git diff --check`, `python3 -m py_compile components/toshiba_ab/__init__.py components/toshiba_ab/climate.py`, and verified with `rg` that no stale `diagnostic_` declarations or `diagnostic_->` dereferences remain, and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a82d114cf48832f81320f38ec4c61a9)