### PR TITLE
Toshiba AB: colored hex logging and diagnostic deduplication

### DIFF
--- a/components/toshiba_ab/toshiba_ab.cpp
+++ b/components/toshiba_ab/toshiba_ab.cpp
@@ -217,8 +217,8 @@ void ToshibaAbClimate::process_frame_(Protocol protocol, const uint8_t *data, si
   const bool master_keepalive = crc_ok && is_master_keepalive_(protocol, data, size, source);
   const char *description =
       master_keepalive ? "master keepalive" : (crc_ok ? "not a master keepalive (ignored)" : "CRC failed");
-  ESP_LOGD(TAG, "RX %s opcode=0x%02X data_type=0x%04X: %s [%s]", protocol_name_(protocol),
-           opcode_(protocol, data, size), data_type_(protocol, data, size), hex_(data, size).c_str(), description);
+  ESP_LOGD(TAG, "RX %s: %s [%s]", protocol_name_(protocol), colored_hex_(protocol, data, size, crc_ok).c_str(),
+           description);
   if (!crc_ok)
     return;
   if (master_keepalive)
@@ -303,6 +303,15 @@ void ToshibaAbClimate::set_runtime_parity_(uart::UARTParityOptions parity) {
 }
 
 void ToshibaAbClimate::diagnostic_(const std::string &message) {
+  // The diagnostic sensor contains a short event history. Periodic frames can
+  // produce the same event repeatedly, but consecutive copies carry no extra
+  // information and would crowd useful discovery messages out of the sensor.
+  const size_t last_message = diagnostic_history_.find_last_of('\n');
+  const size_t last_message_start = last_message == std::string::npos ? 0 : last_message + 1;
+  if (!diagnostic_history_.empty() && diagnostic_history_.size() - last_message_start == message.size() &&
+      diagnostic_history_.compare(last_message_start, message.size(), message) == 0)
+    return;
+
   ESP_LOGI(TAG, "%s", message.c_str());
   if (!diagnostic_history_.empty())
     diagnostic_history_ += '\n';
@@ -356,6 +365,47 @@ std::string ToshibaAbClimate::hex_(const uint8_t *data, size_t size) {
     if (i)
       output += ':';
     output += byte;
+  }
+  return output;
+}
+
+std::string ToshibaAbClimate::colored_hex_(Protocol protocol, const uint8_t *data, size_t size, bool crc_ok) {
+  if (!crc_ok)
+    return ESPHOME_LOG_COLOR(ESPHOME_LOG_COLOR_YELLOW) + hex_(data, size) + ESPHOME_LOG_RESET_COLOR;
+
+  std::string output;
+  char byte[4];
+  for (size_t i = 0; i < size; i++) {
+    if (i)
+      output += ':';
+
+    bool address = false;
+    bool command = false;
+    switch (protocol) {
+      case Protocol::TCC:
+        address = i == 0 || i == 1;
+        command = i == 2 || i == 5;
+        break;
+      case Protocol::TU2C:
+        address = i == 3 || i == 4;
+        command = i == 6 || i == 7;
+        break;
+      case Protocol::A0:
+        address = i == 5 || i == 6 || i == 7 || i == 8;
+        command = i == 2 || i == 9 || i == 10;
+        break;
+      default:
+        break;
+    }
+
+    if (address)
+      output += ESPHOME_LOG_COLOR(ESPHOME_LOG_COLOR_RED);
+    else if (command)
+      output += ESPHOME_LOG_COLOR(ESPHOME_LOG_COLOR_YELLOW);
+    std::snprintf(byte, sizeof(byte), "%02X", data[i]);
+    output += byte;
+    if (address || command)
+      output += ESPHOME_LOG_RESET_COLOR;
   }
   return output;
 }

--- a/components/toshiba_ab/toshiba_ab.h
+++ b/components/toshiba_ab/toshiba_ab.h
@@ -72,6 +72,7 @@ class ToshibaAbClimate : public climate::Climate, public uart::UARTDevice, publi
   static uint8_t opcode_(Protocol protocol, const uint8_t *data, size_t size);
   static uint16_t data_type_(Protocol protocol, const uint8_t *data, size_t size);
   static std::string hex_(const uint8_t *data, size_t size);
+  static std::string colored_hex_(Protocol protocol, const uint8_t *data, size_t size, bool crc_ok);
   static uint16_t crc16_mcrf4xx_(const uint8_t *data, size_t size);
 
   Protocol protocol_setting_{Protocol::AUTO};


### PR DESCRIPTION
### Motivation

- Improve RX debug logs to make address/command bytes visually distinct and highlight CRC failures for easier troubleshooting.
- Prevent the diagnostic text sensor from being flooded by repeated identical messages so useful discovery messages remain visible.

### Description

- Add `colored_hex_` which returns a hex dump with colored address and command bytes and yellow highlighting when CRC is bad.
- Replace the verbose `process_frame_` debug log with a concise call that uses `colored_hex_` to render the packet (`process_frame_` logging now shows protocol plus the colored hex). 
- Add deduplication logic in `diagnostic_` to skip publishing consecutive identical messages and keep the diagnostic history capped at 255 bytes.
- Expose the new `colored_hex_` declaration in the header as `static std::string colored_hex_(Protocol protocol, const uint8_t *data, size_t size, bool crc_ok);`.

### Testing

- Project build completed successfully using the normal build pipeline (`pio run`).
- Existing automated tests for the component suite ran and passed without regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a84f18a3808832fab091e91d68c0bd2)