### PR TITLE
Add automatic Toshiba AB reset button

### DIFF
--- a/components/toshiba_ab/climate.py
+++ b/components/toshiba_ab/climate.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 import esphome.final_validate as fv
-from esphome.components import climate, text_sensor, uart
+from esphome.components import button, climate, text_sensor, uart
 from esphome.const import (
     CONF_ID,
     CONF_NAME,
@@ -13,13 +13,14 @@ from esphome.const import (
 from esphome.core import CORE
 
 DEPENDENCIES = ["uart"]
-AUTO_LOAD = ["text_sensor"]
+AUTO_LOAD = ["button", "text_sensor"]
 CODEOWNERS = ["@muxa"]
 
 toshiba_ab_ns = cg.esphome_ns.namespace("toshiba_ab")
 ToshibaAbClimate = toshiba_ab_ns.class_(
     "ToshibaAbClimate", climate.Climate, uart.UARTDevice, cg.Component
 )
+ResetButton = toshiba_ab_ns.class_("ResetButton", button.Button)
 DiagnosticTextSensor = toshiba_ab_ns.class_(
     "DiagnosticTextSensor", text_sensor.TextSensor
 )
@@ -32,6 +33,7 @@ CONF_FORMAT = "format"
 CONF_SYSTEM_TYPE = "system_type"
 CONF_DIAGNOSTIC = "diagnostic"
 CONF_HARDWARE_UART_RX_PIN = "hardware_uart_rx_pin"
+CONF_RESET_BUTTON = "reset_button"
 AUTO_ADDRESS = 0xAA
 
 
@@ -57,6 +59,11 @@ CONFIG_SCHEMA = (
                 CONF_DIAGNOSTIC, default={CONF_NAME: "Toshiba AB Diagnostic"}
             ): text_sensor.text_sensor_schema(
                 DiagnosticTextSensor, entity_category="diagnostic"
+            ),
+            cv.Optional(
+                CONF_RESET_BUTTON, default={CONF_NAME: "Toshiba AB Reset"}
+            ): button.button_schema(
+                ResetButton, icon="mdi:restart", entity_category="diagnostic"
             ),
             cv.Optional(CONF_MASTER_ADDRESS, default="auto"): _address,
             cv.Optional(CONF_ESP_ADDRESS, default="auto"): _address,
@@ -118,3 +125,6 @@ async def to_code(config):
 
     diagnostic = await text_sensor.new_text_sensor(config[CONF_DIAGNOSTIC])
     cg.add(var.set_diagnostic_sensor(diagnostic))
+
+    reset_button = await button.new_button(config[CONF_RESET_BUTTON])
+    cg.add(reset_button.set_parent(var))

--- a/components/toshiba_ab/toshiba_ab.cpp
+++ b/components/toshiba_ab/toshiba_ab.cpp
@@ -13,6 +13,11 @@ static const char *const TAG = "toshiba_ab";
 constexpr ProtocolValue ToshibaAbClimate::MASTER_KEEPALIVE_OPCODE;
 constexpr ProtocolValue ToshibaAbClimate::MASTER_KEEPALIVE_DATA_TYPE;
 
+void ResetButton::press_action() {
+  if (parent_ != nullptr)
+    parent_->reset();
+}
+
 #ifdef USE_ESP8266
 static HardwareSerial bus_serial(UART0);
 #endif
@@ -31,6 +36,21 @@ void ToshibaAbClimate::setup() {
   if (hardware_uart_rx_pin_ == 13)
     ESP_LOGCONFIG(TAG, "UART0 RX swapped from GPIO3 to GPIO13");
 #endif
+}
+
+void ToshibaAbClimate::reset() {
+  boot_ms_ = millis();
+  master_address_ = master_setting_;
+  master_address_confirmed_ = false;
+  protocol_detected_ = Protocol::AUTO;
+  protocol_confirmed_ = false;
+  discovery_finished_ = false;
+  reader_reset_count_ = 0;
+  diagnostic_history_.clear();
+  select_scan_protocol_(protocol_setting_ == Protocol::AUTO ? Protocol::TCC : protocol_setting_);
+  diagnostic_(protocol_setting_ == Protocol::AUTO
+                  ? "Reset: scanning TCC master keepalives (0-20s)"
+                  : std::string("Reset: listening for a ") + protocol_name_(protocol_setting_) + " master keepalive");
 }
 
 void ToshibaAbClimate::loop() {

--- a/components/toshiba_ab/toshiba_ab.h
+++ b/components/toshiba_ab/toshiba_ab.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "esphome/components/button/button.h"
 #include "esphome/components/climate/climate.h"
 #include "esphome/components/text_sensor/text_sensor.h"
 #include "esphome/components/uart/uart.h"
@@ -12,6 +13,17 @@ namespace toshiba_ab {
 
 enum class Protocol : uint8_t { AUTO, TCC, TU2C, A0 };
 enum class SystemType : uint8_t { AIR, WATER };
+
+class ToshibaAbClimate;
+
+class ResetButton : public button::Button {
+ public:
+  void set_parent(ToshibaAbClimate *parent) { parent_ = parent; }
+
+ protected:
+  void press_action() override;
+  ToshibaAbClimate *parent_{nullptr};
+};
 
 // A semantic field can have a different wire value in every protocol. Keep
 // protocol-specific values together rather than spreading magic numbers
@@ -36,6 +48,7 @@ class ToshibaAbClimate : public climate::Climate, public uart::UARTDevice, publi
   float get_setup_priority() const override { return setup_priority::DATA; }
   climate::ClimateTraits traits() override;
   void control(const climate::ClimateCall &call) override;
+  void reset();
 
   void set_master_address(uint8_t address) { master_setting_ = address; }
   void set_esp_address(uint8_t address) { esp_address_ = address; }


### PR DESCRIPTION
### Motivation

- Provide an automatically-created reset push button for the Toshiba AB component so users do not need to add a YAML entry to get a diagnostic reset control. 

### Description

- Expose the `button` component in the Python generator and add `ResetButton` to `AUTO_LOAD`, introduce `CONF_RESET_BUTTON`, and add a config schema entry using `button.button_schema` so a reset button is created automatically for each `toshiba_ab` instance, with a default name and icon. 
- Wire generation: create the button in `to_code` (`button.new_button(...)`) and set its parent to the `ToshibaAbClimate` instance so button presses route to the component. 
- C++ changes: add `#include

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a84f5260200832fa0197e87eb3856da)