### PR TITLE
Expose full climate traits for AIR system in identification-only Toshiba AB component

### DIFF
--- a/components/toshiba_ab/toshiba_ab.cpp
+++ b/components/toshiba_ab/toshiba_ab.cpp
@@ -442,7 +442,30 @@ uint16_t ToshibaAbClimate::crc16_mcrf4xx_(const uint8_t *data, size_t size) {
 
 climate::ClimateTraits ToshibaAbClimate::traits() {
   auto traits = climate::ClimateTraits();
-  traits.set_supported_modes({climate::CLIMATE_MODE_OFF});
+  if (system_type_ == SystemType::AIR) {
+    // Identification mode must still expose the complete climate capability
+    // schema. This makes every field available in the native API response
+    // while protocol support is being rebuilt incrementally.
+    traits.set_feature_flags(climate::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE |
+                             climate::CLIMATE_SUPPORTS_TWO_POINT_TARGET_TEMPERATURE |
+                             climate::CLIMATE_SUPPORTS_CURRENT_HUMIDITY | climate::CLIMATE_SUPPORTS_TARGET_HUMIDITY |
+                             climate::CLIMATE_SUPPORTS_ACTION);
+    traits.set_supported_modes({climate::CLIMATE_MODE_OFF, climate::CLIMATE_MODE_HEAT_COOL, climate::CLIMATE_MODE_COOL,
+                                climate::CLIMATE_MODE_HEAT, climate::CLIMATE_MODE_FAN_ONLY, climate::CLIMATE_MODE_DRY,
+                                climate::CLIMATE_MODE_AUTO});
+    traits.set_supported_fan_modes({climate::CLIMATE_FAN_ON, climate::CLIMATE_FAN_OFF, climate::CLIMATE_FAN_AUTO,
+                                    climate::CLIMATE_FAN_LOW, climate::CLIMATE_FAN_MEDIUM, climate::CLIMATE_FAN_HIGH,
+                                    climate::CLIMATE_FAN_MIDDLE, climate::CLIMATE_FAN_FOCUS,
+                                    climate::CLIMATE_FAN_DIFFUSE, climate::CLIMATE_FAN_QUIET});
+    traits.set_supported_swing_modes({climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_BOTH,
+                                      climate::CLIMATE_SWING_VERTICAL, climate::CLIMATE_SWING_HORIZONTAL});
+    traits.set_supported_presets({climate::CLIMATE_PRESET_NONE, climate::CLIMATE_PRESET_HOME,
+                                  climate::CLIMATE_PRESET_AWAY, climate::CLIMATE_PRESET_BOOST,
+                                  climate::CLIMATE_PRESET_COMFORT, climate::CLIMATE_PRESET_ECO,
+                                  climate::CLIMATE_PRESET_SLEEP, climate::CLIMATE_PRESET_ACTIVITY});
+  } else {
+    traits.set_supported_modes({climate::CLIMATE_MODE_OFF});
+  }
   traits.set_visual_min_temperature(5);
   traits.set_visual_max_temperature(35);
   traits.set_visual_temperature_step(0.5);


### PR DESCRIPTION
### Motivation

- Identification mode should expose the complete climate capability schema so the native API response shows all fields while protocol support is rebuilt incrementally.
- Only `SystemType::AIR` should present full capabilities; non-air (water) systems remain identification-only with `OFF` mode.

### Description

- Updated `ToshibaAbClimate::traits()` to conditionally provide full capability flags and mode lists when `system_type_ == SystemType::AIR` by setting `set_feature_flags`, `set_supported_modes`, `set_supported_fan_modes`, `set_supported_swing_modes`, and `set_supported_presets`.
- Kept the non-AIR branch returning only `climate::CLIMATE_MODE_OFF` for identification-only water systems.
- Left visual temperature bounds via `set_visual_min_temperature`, `set_visual_max_temperature`, and `set_visual_temperature_step` unchanged.

### Testing

- Project builds cleanly for the target using `platformio` (no compilation errors observed). 
- Existing automated tests executed without failures (no regressions reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a85048d04ac832fa1ca40ff3f1628ee)