### PR TITLE
Expose six raw Estia temperature sensors in Toshiba AB climate component

### DIFF
--- a/components/toshiba_ab/climate.py
+++ b/components/toshiba_ab/climate.py
@@ -63,6 +63,12 @@ CONF_PING = "ping"
 
 # Estia-specific sensors
 CONF_OUTDOOR_TEMPERATURE = "outdoor_temperature"
+CONF_TEMP1 = "temp1"
+CONF_TEMP2 = "temp2"
+CONF_TEMP3 = "temp3"
+CONF_TEMP4 = "temp4"
+CONF_TEMP5 = "temp5"
+CONF_TEMP6 = "temp6"
 CONF_COMPRESSOR_HOURS = "compressor_hours"
 CONF_WATERPUMP_HOURS = "waterpump_hours"
 CONF_BACKUP_HEATER_HOURS = "backup_heater_hours"
@@ -327,6 +333,42 @@ CONFIG_SCHEMA = climate._CLIMATE_SCHEMA.extend(
             device_class=DEVICE_CLASS_TEMPERATURE,
             state_class=STATE_CLASS_MEASUREMENT,
         ),
+        cv.Optional(CONF_TEMP1): sensor.sensor_schema(
+            unit_of_measurement=UNIT_CELSIUS,
+            accuracy_decimals=1,
+            device_class=DEVICE_CLASS_TEMPERATURE,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        cv.Optional(CONF_TEMP2): sensor.sensor_schema(
+            unit_of_measurement=UNIT_CELSIUS,
+            accuracy_decimals=1,
+            device_class=DEVICE_CLASS_TEMPERATURE,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        cv.Optional(CONF_TEMP3): sensor.sensor_schema(
+            unit_of_measurement=UNIT_CELSIUS,
+            accuracy_decimals=1,
+            device_class=DEVICE_CLASS_TEMPERATURE,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        cv.Optional(CONF_TEMP4): sensor.sensor_schema(
+            unit_of_measurement=UNIT_CELSIUS,
+            accuracy_decimals=1,
+            device_class=DEVICE_CLASS_TEMPERATURE,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        cv.Optional(CONF_TEMP5): sensor.sensor_schema(
+            unit_of_measurement=UNIT_CELSIUS,
+            accuracy_decimals=1,
+            device_class=DEVICE_CLASS_TEMPERATURE,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        cv.Optional(CONF_TEMP6): sensor.sensor_schema(
+            unit_of_measurement=UNIT_CELSIUS,
+            accuracy_decimals=1,
+            device_class=DEVICE_CLASS_TEMPERATURE,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
         cv.Optional(CONF_COMPRESSOR_HOURS): sensor.sensor_schema(
             unit_of_measurement=UNIT_HOUR,
             accuracy_decimals=0,
@@ -535,6 +577,24 @@ async def to_code(config):
     if CONF_OUTDOOR_TEMPERATURE in config:
         sens = await sensor.new_sensor(config[CONF_OUTDOOR_TEMPERATURE])
         cg.add(var.set_outdoor_temp_sensor(sens))
+    if CONF_TEMP1 in config:
+        sens = await sensor.new_sensor(config[CONF_TEMP1])
+        cg.add(var.set_temp1_sensor(sens))
+    if CONF_TEMP2 in config:
+        sens = await sensor.new_sensor(config[CONF_TEMP2])
+        cg.add(var.set_temp2_sensor(sens))
+    if CONF_TEMP3 in config:
+        sens = await sensor.new_sensor(config[CONF_TEMP3])
+        cg.add(var.set_temp3_sensor(sens))
+    if CONF_TEMP4 in config:
+        sens = await sensor.new_sensor(config[CONF_TEMP4])
+        cg.add(var.set_temp4_sensor(sens))
+    if CONF_TEMP5 in config:
+        sens = await sensor.new_sensor(config[CONF_TEMP5])
+        cg.add(var.set_temp5_sensor(sens))
+    if CONF_TEMP6 in config:
+        sens = await sensor.new_sensor(config[CONF_TEMP6])
+        cg.add(var.set_temp6_sensor(sens))
     if CONF_COMPRESSOR_HOURS in config:
         sens = await sensor.new_sensor(config[CONF_COMPRESSOR_HOURS])
         cg.add(var.set_compressor_hours_sensor(sens))

--- a/components/toshiba_ab/toshiba_ab.cpp
+++ b/components/toshiba_ab/toshiba_ab.cpp
@@ -2395,6 +2395,30 @@ bool ToshibaAbClimate::receive_data_frame(const struct DataFrame *frame) {
         this->outdoor_temp_sensor_->publish_state(outdoor_temp);
       }
 
+      // Also expose all six raw status temperatures while their purposes are
+      // still being identified. The established climate and outdoor states
+      // above remain unchanged.
+      if (this->temp1_sensor_ != nullptr) {
+        this->temp1_sensor_->publish_state(current_temp);
+      }
+      if (this->temp2_sensor_ != nullptr) {
+        this->temp2_sensor_->publish_state(setpoint);
+      }
+      if (this->temp3_sensor_ != nullptr) {
+        this->temp3_sensor_->publish_state(outdoor_temp);
+      }
+      if (frame_len >= 18) {
+        if (this->temp4_sensor_ != nullptr) {
+          this->temp4_sensor_->publish_state(frame->raw[15] / 2.0f - 16.0f);
+        }
+        if (this->temp5_sensor_ != nullptr) {
+          this->temp5_sensor_->publish_state(frame->raw[16] / 2.0f - 16.0f);
+        }
+        if (this->temp6_sensor_ != nullptr) {
+          this->temp6_sensor_->publish_state(frame->raw[17] / 2.0f - 16.0f);
+        }
+      }
+
       last_master_alive_millis_ = millis();
       if (this->connected_binary_sensor_) {
         this->connected_binary_sensor_->publish_state(true);

--- a/components/toshiba_ab/toshiba_ab.h
+++ b/components/toshiba_ab/toshiba_ab.h
@@ -853,6 +853,12 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
   void set_command_mode_write(uint8_t value) { command_mode_write_ = value; }
   void set_filter_alert_sensor(binary_sensor::BinarySensor *sensor) { filter_alert_sensor_ = sensor; }
   void set_outdoor_temp_sensor(sensor::Sensor *sensor) { outdoor_temp_sensor_ = sensor; }
+  void set_temp1_sensor(sensor::Sensor *sensor) { temp1_sensor_ = sensor; }
+  void set_temp2_sensor(sensor::Sensor *sensor) { temp2_sensor_ = sensor; }
+  void set_temp3_sensor(sensor::Sensor *sensor) { temp3_sensor_ = sensor; }
+  void set_temp4_sensor(sensor::Sensor *sensor) { temp4_sensor_ = sensor; }
+  void set_temp5_sensor(sensor::Sensor *sensor) { temp5_sensor_ = sensor; }
+  void set_temp6_sensor(sensor::Sensor *sensor) { temp6_sensor_ = sensor; }
   void set_compressor_hours_sensor(sensor::Sensor *sensor) { compressor_hours_sensor_ = sensor; }
   void set_waterpump_hours_sensor(sensor::Sensor *sensor) { waterpump_hours_sensor_ = sensor; }
   void set_backup_heater_hours_sensor(sensor::Sensor *sensor) { backup_heater_hours_sensor_ = sensor; }
@@ -1079,6 +1085,12 @@ class ToshibaAbClimate : public Component, public uart::UARTDevice, public clima
 
   // Estia sensors
   sensor::Sensor *outdoor_temp_sensor_{nullptr};
+  sensor::Sensor *temp1_sensor_{nullptr};
+  sensor::Sensor *temp2_sensor_{nullptr};
+  sensor::Sensor *temp3_sensor_{nullptr};
+  sensor::Sensor *temp4_sensor_{nullptr};
+  sensor::Sensor *temp5_sensor_{nullptr};
+  sensor::Sensor *temp6_sensor_{nullptr};
   sensor::Sensor *compressor_hours_sensor_{nullptr};
   sensor::Sensor *waterpump_hours_sensor_{nullptr};
   sensor::Sensor *backup_heater_hours_sensor_{nullptr};


### PR DESCRIPTION
### Motivation

- Add visibility into six raw Estia temperature/status values while their meanings are being identified so they can be observed in Home Assistant for debugging and mapping.

### Description

- Add six new configuration keys `CONF_TEMP1`..`CONF_TEMP6` and corresponding sensor schemas in `components/toshiba_ab/climate.py` so users can declare sensors for these values.
- Add sensor member variables and setter methods `set_temp1_sensor`..`set_temp6_sensor` to `ToshibaAbClimate` in `components/toshiba_ab/toshiba_ab.h` and initialize corresponding pointers.
- Publish the six temperature values from `receive_data_frame` in `components/toshiba_ab/toshiba_ab.cpp`, mapping `temp1` to the current temperature, `temp2` to the setpoint, `temp3` to the outdoor temperature, and `temp4`–`temp6` from `frame->raw[15..17]` converted with the formula `raw / 2.0f - 16.0f` when the frame length allows it.
- Wire the new config keys into `to_code` to create and attach the sensor objects when configured.

### Testing

- No automated tests were added for these changes and no CI test results are included in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a819fe7626c832f9eb633415f771e2c)